### PR TITLE
Implement sorting feature with tests

### DIFF
--- a/__tests__/components/SortMenu.test.tsx
+++ b/__tests__/components/SortMenu.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SortMenu from '../../components/SortMenu';
+import { useRouter } from 'next/router';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+describe('SortMenu', () => {
+  const pushMock = jest.fn();
+
+  beforeEach(() => {
+    (useRouter as jest.Mock).mockReturnValue({
+      pathname: '/category/electronics',
+      query: {},
+      push: pushMock,
+    });
+    pushMock.mockClear();
+  });
+
+  it('renders sorting options', () => {
+    render(<SortMenu />);
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Price: Low to High' })).toBeInTheDocument();
+  });
+
+  it('updates route query on change', () => {
+    render(<SortMenu />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'price-asc' } });
+    expect(pushMock).toHaveBeenCalledWith(
+      {
+        pathname: '/category/electronics',
+        query: { sort: 'price-asc' },
+      },
+      undefined,
+      { shallow: true }
+    );
+  });
+});

--- a/__tests__/lib/api.test.ts
+++ b/__tests__/lib/api.test.ts
@@ -161,4 +161,16 @@ describe('fetchCategoryWithProducts - BFF Filtering Logic (Updated Tests)', () =
     expect(result?.products[0].name).toBe('Wireless Headphones');
     expect(result?.products[0].size).toBe('Large');
   });
+
+  it('should sort products by price ascending', async () => {
+    const result = await fetchCategoryWithProducts(electronicsCategorySlug, {}, 'price-asc');
+    const prices = result!.products.map(p => p.price);
+    expect(prices).toEqual([199, 499.99, 799.5]);
+  });
+
+  it('should sort products by newest first', async () => {
+    const result = await fetchCategoryWithProducts(electronicsCategorySlug, {}, 'newest');
+    const ids = result!.products.map(p => p.id);
+    expect(ids).toEqual(['prod3', 'prod2', 'prod1']);
+  });
 });

--- a/bff/data/mock-category-data.json
+++ b/bff/data/mock-category-data.json
@@ -2,9 +2,9 @@
   {
     "category": { "id": "cat1", "name": "Electronics", "slug": "electronics" },
     "products": [
-      { "id": "prod1", "name": "Smart TV", "price": 499.99, "brand": "TechBrand", "size": "55-inch", "imageUrl": "/images/tv.jpg" },
-      { "id": "prod2", "name": "Wireless Headphones", "price": 199.00, "brand": "AudioMax", "size": "Large", "imageUrl": "/images/headphones.jpg" },
-      { "id": "prod3", "name": "Smartphone X1", "price": 799.50, "brand": "MobileCorp", "size": "6-inch", "imageUrl": "/images/smartphone.jpg" }
+      { "id": "prod1", "name": "Smart TV", "price": 499.99, "brand": "TechBrand", "size": "55-inch", "imageUrl": "/images/tv.jpg", "createdAt": "2023-08-01T10:00:00Z" },
+      { "id": "prod2", "name": "Wireless Headphones", "price": 199.00, "brand": "AudioMax", "size": "Large", "imageUrl": "/images/headphones.jpg", "createdAt": "2023-08-05T12:00:00Z" },
+      { "id": "prod3", "name": "Smartphone X1", "price": 799.50, "brand": "MobileCorp", "size": "6-inch", "imageUrl": "/images/smartphone.jpg", "createdAt": "2023-08-10T15:30:00Z" }
     ],
     "facets": {
       "brand": ["TechBrand", "AudioMax", "MobileCorp"],
@@ -14,9 +14,9 @@
   {
     "category": { "id": "cat2", "name": "Apparel", "slug": "apparel" },
     "products": [
-      { "id": "prod4", "name": "Men's T-Shirt", "price": 25.00, "brand": "FashionCo", "size": "M", "imageUrl": "/images/tshirt.jpg" },
-      { "id": "prod5", "name": "Women's Jeans", "price": 75.00, "brand": "StyleStitch", "size": "S", "imageUrl": "/images/jeans.jpg" },
-      { "id": "prod6", "name": "Running Shoes", "price": 120.00, "brand": "FashionCo", "size": "10", "imageUrl": "/images/shoes.jpg" }
+      { "id": "prod4", "name": "Men's T-Shirt", "price": 25.00, "brand": "FashionCo", "size": "M", "imageUrl": "/images/tshirt.jpg", "createdAt": "2023-07-20T08:45:00Z" },
+      { "id": "prod5", "name": "Women's Jeans", "price": 75.00, "brand": "StyleStitch", "size": "S", "imageUrl": "/images/jeans.jpg", "createdAt": "2023-07-25T11:15:00Z" },
+      { "id": "prod6", "name": "Running Shoes", "price": 120.00, "brand": "FashionCo", "size": "10", "imageUrl": "/images/shoes.jpg", "createdAt": "2023-08-02T09:30:00Z" }
     ],
     "facets": {
       "brand": ["FashionCo", "StyleStitch"],

--- a/components/SortMenu.tsx
+++ b/components/SortMenu.tsx
@@ -1,0 +1,30 @@
+import { useRouter } from 'next/router';
+
+const SortMenu = () => {
+  const router = useRouter();
+  const sort = Array.isArray(router.query.sort)
+    ? router.query.sort[0]
+    : (router.query.sort as string | undefined);
+
+  const updateSort = (value: string) => {
+    router.push({
+      pathname: router.pathname,
+      query: { ...router.query, sort: value || undefined },
+    }, undefined, { shallow: true });
+  };
+
+  return (
+    <select
+      aria-label="Sort products"
+      value={sort || ''}
+      onChange={(e) => updateSort(e.target.value)}
+    >
+      <option value="">Sort by</option>
+      <option value="price-asc">Price: Low to High</option>
+      <option value="price-desc">Price: High to Low</option>
+      <option value="newest">Newest First</option>
+    </select>
+  );
+};
+
+export default SortMenu;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -8,6 +8,7 @@ export interface Product {
   brand: string;
   size: string; // Assuming size is a string, e.g., "S", "M", "L", "XL"
   imageUrl: string;
+  createdAt: string;
 }
 
 // Define Category data structure
@@ -85,9 +86,15 @@ const applyFiltersToProducts = (
 
 export const fetchCategoryWithProducts = async (
   slug: string,
-  activeFilters?: ActiveFilters
+  activeFilters?: ActiveFilters,
+  sort?: string
 ): Promise<CategoryPageData | null> => {
-  console.log(`BFF: Fetching category with products for slug: ${slug}. Filters:`, activeFilters || {});
+  console.log(
+    `BFF: Fetching category with products for slug: ${slug}. Filters:`,
+    activeFilters || {},
+    'Sort:',
+    sort
+  );
 
   const allCategoryDataSources: CategoryPageData[] = MOCK_CATEGORIES_DATA_JSON;
   const categoryPageItem = allCategoryDataSources.find(item => item.category.slug === slug);
@@ -109,6 +116,16 @@ export const fetchCategoryWithProducts = async (
     console.log(`BFF: Found ${productsToReturn.length} products after filtering for slug "${slug}".`);
   } else {
     console.log(`BFF: No filters applied, returning all ${productsToReturn.length} products for slug "${slug}".`);
+  }
+
+  if (sort === 'price-asc') {
+    productsToReturn.sort((a, b) => a.price - b.price);
+  } else if (sort === 'price-desc') {
+    productsToReturn.sort((a, b) => b.price - a.price);
+  } else if (sort === 'newest') {
+    productsToReturn.sort(
+      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    );
   }
 
   return {

--- a/pages/category/[slug].tsx
+++ b/pages/category/[slug].tsx
@@ -2,6 +2,7 @@
 import { useRouter } from 'next/router';
 import Layout from '@/components/Layout';
 import ProductList from '@/components/ProductList'; // Corrected import: default export
+import SortMenu from '@/components/SortMenu';
 import FacetFilters, { ActiveFilters } // Import ActiveFilters and FacetFilters
     from '@/components/FacetFilters';
 import { GetStaticPropsContext, GetStaticPropsResult } from 'next';
@@ -31,6 +32,9 @@ const CategoryPage = ({ initialCategoryData, initialSlug }: CategoryPageProps) =
   const [activeFilters, setActiveFilters] = useState<ActiveFilters>({});
   const [isLoading, setIsLoading] = useState(false);
   const [isMobileFiltersOpen, setIsMobileFiltersOpen] = useState(false);
+  const sortParam = Array.isArray(router.query.sort)
+    ? router.query.sort[0]
+    : (router.query.sort as string | undefined);
 
   // Effect for URL to State synchronization
   useEffect(() => {
@@ -116,7 +120,7 @@ const CategoryPage = ({ initialCategoryData, initialSlug }: CategoryPageProps) =
         // It might need refinement based on exact timing and router.isReady behavior.
     } else {
         setIsLoading(true);
-        fetchCategoryWithProducts(slugToFetch, activeFilters)
+        fetchCategoryWithProducts(slugToFetch, activeFilters, sortParam)
           .then(data => {
             setDisplayedCategoryData(data);
           })
@@ -129,7 +133,7 @@ const CategoryPage = ({ initialCategoryData, initialSlug }: CategoryPageProps) =
           });
     }
 
-  }, [activeFilters, initialSlug, router.query.slug, router.isReady]); // router.isReady added
+  }, [activeFilters, initialSlug, router.query.slug, router.isReady, sortParam]); // include sortParam
 
 
   const handleFilterChangeCallback = (newFilters: ActiveFilters) => {
@@ -177,6 +181,7 @@ const CategoryPage = ({ initialCategoryData, initialSlug }: CategoryPageProps) =
             />
           </aside>
           <main className={styles.productListArea}>
+            <SortMenu />
             {!isLoading && <ProductList products={products} />}
           </main>
         </div>

--- a/types/index.ts
+++ b/types/index.ts
@@ -21,4 +21,5 @@ export type Product = {
   slug: string;
   price: number;
   imageUrl: string;
+  createdAt: string;
 };


### PR DESCRIPTION
## Summary
- add `SortMenu` component and unit tests
- add `createdAt` dates to mock products
- update API to sort on server
- wire up SortMenu on category page and pass sort param
- add API sorting tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f5304dd8832a99fd2ef3514feb1e