### PR TITLE
Fix import syntax in category page

### DIFF
--- a/pages/category/[slug].tsx
+++ b/pages/category/[slug].tsx
@@ -1,9 +1,8 @@
 // pages/category/[slug].tsx
 import { useRouter } from 'next/router';
 import Layout from '@/components/Layout';
-import ProductList from '@/components/ProductList'; // Corrected import: default export
-import FacetFilters, { ActiveFilters } // Import ActiveFilters and FacetFilters
-    from '@/components/FacetFilters';
+import ProductList from '@/components/ProductList';
+import FacetFilters, { ActiveFilters } from '@/components/FacetFilters';
 import { GetStaticPropsContext, GetStaticPropsResult } from 'next';
 import { ParsedUrlQuery } from 'querystring';
 import {


### PR DESCRIPTION
## Summary
- fix invalid import statement in `pages/category/[slug].tsx`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f1f8ae9c832abcbb4b96737eeff0