### PR TITLE
Add jest/node types to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "incremental": true,
     "paths": {
       "@/*": ["./*"]
-    }
+    },
+    "types": ["jest", "node"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- add `types` entry so TS knows about jest and node globals

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'jest' and 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684a97459750832aaf5bee220dc3ba4f