### PR TITLE
Fix: Correct product carousel link to /product/[slug]

### DIFF
--- a/__tests__/components/FeaturedProductsCarousel.test.tsx
+++ b/__tests__/components/FeaturedProductsCarousel.test.tsx
@@ -50,7 +50,7 @@ describe('FeaturedProductsCarousel', () => {
 
       // Check product link
       const linkElement = screen.getByRole('link', { name: new RegExp(product.name, 'i') });
-      expect(linkElement).toHaveAttribute('href', `/products/${product.slug}`);
+      expect(linkElement).toHaveAttribute('href', `/product/${product.slug}`);
 
       // Check product image
       const imageElement = screen.getByAltText(product.name);

--- a/components/FeaturedProductsCarousel.tsx
+++ b/components/FeaturedProductsCarousel.tsx
@@ -12,7 +12,7 @@ export default function FeaturedProductsCarousel({ products }: Props) {
       <h2>Featured Products</h2>
       <div className={styles.carousel}>
         {products.map((product) => (
-          <a key={product.id} href={`/products/${product.slug}`} className={styles.productCard}>
+          <a key={product.id} href={`/product/${product.slug}`} className={styles.productCard}>
             <img src={product.imageUrl} alt={product.name} />
             <h3>{product.name}</h3>
             <p>${product.price.toFixed(2)}</p>


### PR DESCRIPTION
The product carousel on the home page was incorrectly linking to /products/[slug] instead of the correct /product/[slug].

This commit updates the `FeaturedProductsCarousel.tsx` component to use the correct link format. The corresponding unit test in `FeaturedProductsCarousel.test.tsx` has also been updated to reflect this change.

Note: The test suite execution was consistently timing out, even for simple operations like clearing the cache. This appears to be an existing issue with the testing environment and prevented me from confirming that the tests pass for this change.