### PR TITLE
Implement product detail page

### DIFF
--- a/__tests__/bff/products.test.js
+++ b/__tests__/bff/products.test.js
@@ -1,5 +1,6 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { getProducts } from '../../bff/products/index.js';
+import { getProduct } from '../../bff/products/index.js';
 import * as fetchDataModule from '../../bff/utils/fetchData.js';
 
 // Mock applicationinsights
@@ -168,6 +169,35 @@ describe('BFF Products Service - getProducts', () => {
     });
 
     expect(mockTrackMetric).not.toHaveBeenCalled();
+    expect(mockTrackException).not.toHaveBeenCalled();
+  });
+});
+
+describe('BFF Products Service - getProduct', () => {
+  let fetchDataSpy;
+
+  beforeEach(() => {
+    fetchDataSpy = vi.spyOn(fetchDataModule, 'fetchData');
+    mockTrackTrace.mockClear();
+    mockTrackEvent.mockClear();
+    mockTrackMetric.mockClear();
+    mockTrackException.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches a single product and logs telemetry', async () => {
+    const mockProduct = { id: 1, title: 'Phone' };
+    fetchDataSpy.mockResolvedValue(mockProduct);
+
+    const result = await getProduct(1);
+
+    expect(result).toEqual(mockProduct);
+    expect(fetchDataSpy).toHaveBeenCalledWith('https://dummyjson.com/products/1');
+    expect(mockTrackTrace).toHaveBeenCalled();
+    expect(mockTrackEvent).toHaveBeenCalled();
     expect(mockTrackException).not.toHaveBeenCalled();
   });
 });

--- a/bff/products/index.js
+++ b/bff/products/index.js
@@ -41,3 +41,34 @@ export async function getProducts() {
     throw error; // Re-throw the error so the caller can handle it
   }
 }
+
+/**
+ * Fetches a single product by id from dummyjson.com.
+ * @param {string|number} id - The product id.
+ * @returns {Promise<Object>} The product data.
+ */
+export async function getProduct(id) {
+  const client = appInsights.defaultClient;
+  try {
+    client.trackTrace({
+      message: 'Calling dummyjson for product detail',
+      severity: 1,
+      properties: { origin: 'bff/products', method: 'getProduct', id: String(id) },
+    });
+
+    const data = await fetchData(`https://dummyjson.com/products/${id}`);
+
+    client.trackEvent({
+      name: 'ProductFetchSuccess',
+      properties: { id: String(id) },
+    });
+
+    return data;
+  } catch (error) {
+    client.trackException({
+      exception: error,
+      properties: { origin: 'bff/products', method: 'getProduct' },
+    });
+    throw error;
+  }
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -211,6 +211,27 @@ export async function fetchSearchResults(query: string): Promise<Product[]> {
   }));
 }
 
+export async function fetchProductById(id: string): Promise<Product | null> {
+  const CMS_BASE_URL =
+    process.env.NEXT_PUBLIC_CMS_BASE_URL || 'https://dummyjson.com';
+  const res = await fetch(`${CMS_BASE_URL}/products/${id}`);
+  if (!res.ok) {
+    console.error('Failed to fetch product', id, res.status);
+    return null;
+  }
+  const p = await res.json();
+  return {
+    id: p.id?.toString() || '',
+    name: p.title,
+    slug: p.id?.toString() || '',
+    price: p.price,
+    brand: p.brand || '',
+    size: p.size || '',
+    imageUrl: p.thumbnail,
+    createdAt: p.createdAt || '',
+  };
+}
+
 // Placeholder for CMS_BASE_URL, should be set in environment variables
 const CMS_BASE_URL = process.env.NEXT_PUBLIC_CMS_BASE_URL || 'https://dummyjson.com'; // Using NEXT_PUBLIC_ prefix for client-side access if needed, or just process.env for server-side. For getStaticProps, process.env is fine.
 

--- a/pages/api/products/[id].js
+++ b/pages/api/products/[id].js
@@ -1,0 +1,20 @@
+import { setupTelemetry } from '../../../lib/telemetry.js';
+import { getProduct } from '../../../bff/products/index.js';
+
+setupTelemetry();
+
+export default async function handler(req, res) {
+  const { id } = req.query;
+  if (!id) {
+    res.status(400).json({ error: 'Missing product id' });
+    return;
+  }
+
+  try {
+    const product = await getProduct(id);
+    res.status(200).json(product);
+  } catch (error) {
+    console.error('[API] getProduct error:', error);
+    res.status(500).json({ error: 'Failed to fetch product', details: error.message });
+  }
+}

--- a/pages/products/[id].tsx
+++ b/pages/products/[id].tsx
@@ -1,0 +1,43 @@
+import { GetServerSidePropsContext } from 'next';
+import Layout from '@/components/Layout';
+import BreadcrumbNav from '@/components/BreadcrumbNav';
+import { fetchCategories, fetchProductById } from '@/lib/api';
+import type { Category, Product } from '@/types';
+
+interface ProductPageProps {
+  categories: Category[];
+  product: Product;
+}
+
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  const { id } = context.params ?? {};
+  let categories: Category[] = [];
+  let product: Product | null = null;
+
+  try {
+    categories = await fetchCategories();
+    if (typeof id === 'string') {
+      product = await fetchProductById(id);
+    }
+  } catch (error) {
+    console.error('Error loading product page:', error);
+  }
+
+  if (!product) {
+    return { notFound: true };
+  }
+
+  return { props: { categories, product } };
+}
+
+export default function ProductPage({ categories, product }: ProductPageProps) {
+  return (
+    <Layout categories={categories}>
+      <BreadcrumbNav />
+      <div>
+        <h1>{product.name}</h1>
+        <p>Price: {product.price}</p>
+      </div>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- add BFF `getProduct` helper and API route for `/api/products/[id]`
- implement `fetchProductById` client util
- add dynamic product page under `/products/[id]`
- cover new BFF helper with tests

## Testing
- `npm test` *(fails: jest not installed)*
- `npx vitest run` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684d438db4ac832a87ced506054b853f