### PR TITLE
feat: search bar in navbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+reports/
+

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,10 @@
+export function logDebug(...args: unknown[]) {
+  if (process.env.NODE_ENV !== 'production') {
+    console.debug(...args);
+  }
+}
+
+export function logError(...args: unknown[]) {
+  console.error(...args);
+}
+

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -4,6 +4,7 @@ import CredentialsProvider from 'next-auth/providers/credentials';
 import { login as bffLogin } from '@/bff/services'; // Your BFF login service
 import { AuthResponseSchema } from '@/bff/types'; // Removed UserSchema as it's unused
 import { z } from 'zod';
+import { logError } from "@/lib/logger";
 
 // Augment NextAuth types to include 'role' and 'id' on user and session
 declare module 'next-auth' {
@@ -42,7 +43,7 @@ export const authOptions: NextAuthOptions = {
       async authorize(credentials) { // Removed _req
         if (!credentials?.username || !credentials?.password) {
           if (process.env.NODE_ENV !== 'production') {
-            console.error('Auth: Missing username or password in credentials');
+            logError('Auth: Missing username or password in credentials');
           }
           return null;
         }
@@ -83,11 +84,11 @@ export const authOptions: NextAuthOptions = {
         } catch (error: unknown) { // Changed error type to unknown
           if (process.env.NODE_ENV !== 'production') {
             if (error instanceof z.ZodError) {
-              console.error('Auth: Zod validation error in authorize callback:', error.errors);
+              logError('Auth: Zod validation error in authorize callback:', error.errors);
             } else if (error instanceof Error) { // Check if error is an instance of Error
-              console.error('Auth: Error in authorize callback:', error.message);
+              logError('Auth: Error in authorize callback:', error.message);
             } else {
-              console.error('Auth: Unknown error in authorize callback:', error);
+              logError('Auth: Unknown error in authorize callback:', error);
             }
           }
           // Regardless of error type, return null for auth failure

--- a/src/bff/helpers/absoluteUrl.spec.ts
+++ b/src/bff/helpers/absoluteUrl.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { absoluteUrl } from './absoluteUrl';
+
+describe('absoluteUrl', () => {
+  it('uses forwarded headers when present', () => {
+    const req = {
+      headers: {
+        'x-forwarded-host': 'preview.example.com',
+        'x-forwarded-proto': 'https'
+      }
+    };
+    expect(absoluteUrl(req, '/api/foo')).toBe('https://preview.example.com/api/foo');
+  });
+
+  it('falls back to host header', () => {
+    const req = {
+      headers: {
+        host: 'localhost:3000'
+      }
+    };
+    expect(absoluteUrl(req, '/api/foo')).toBe('http://localhost:3000/api/foo');
+  });
+
+  it('uses localhost when no headers present', () => {
+    const req = { headers: {} };
+    expect(absoluteUrl(req, '/api/foo')).toBe('http://localhost:3000/api/foo');
+  });
+});
+

--- a/src/bff/helpers/absoluteUrl.ts
+++ b/src/bff/helpers/absoluteUrl.ts
@@ -1,0 +1,19 @@
+export function absoluteUrl(
+  req: { headers: Record<string, string | string[] | undefined> },
+  path = ''
+): string {
+  const host = (req.headers['x-forwarded-host'] ?? req.headers['host']) as string | undefined;
+  let protocol: string | undefined;
+  const protoHeader = req.headers['x-forwarded-proto'] ?? req.headers['x-forwarded-protocol'];
+  if (Array.isArray(protoHeader)) {
+    protocol = protoHeader[0];
+  } else if (typeof protoHeader === 'string') {
+    protocol = protoHeader.split(',')[0];
+  }
+  if (!protocol) {
+    protocol = host && host.includes('localhost') ? 'http' : 'https';
+  }
+  const finalHost = host ?? 'localhost:3000';
+  return `${protocol}://${finalHost}${path}`;
+}
+

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -3,6 +3,7 @@
 
 import { Disclosure, Menu, Transition } from '@headlessui/react';
 import { Bars3Icon, XMarkIcon, UserCircleIcon, ShoppingCartIcon } from '@heroicons/react/24/outline'; // Keep outline or solid consistently
+import SearchBar from './SearchBar';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useSession, signOut } from 'next-auth/react';
@@ -131,8 +132,11 @@ export default function NavBar({ initialCategories, categoryError }: NavBarProps
                 </div>
               </div>
 
-              {/* Right side icons: Cart and Auth */}
-              <div className="absolute inset-y-0 right-0 flex items-center pr-2 sm:static sm:inset-auto sm:ml-6 sm:pr-0">
+              {/* Right side icons and search */}
+              <div className="absolute inset-y-0 right-0 flex items-center space-x-3 pr-2 sm:static sm:inset-auto sm:ml-6 sm:pr-0">
+                <div className="hidden sm:block w-48">
+                  <SearchBar />
+                </div>
                 <Link href="/cart" className="relative rounded-full bg-gray-800 p-1 text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800" title="View Cart">
                   <span className="sr-only">View Cart</span>
                   <ShoppingCartIcon className="h-6 w-6" aria-hidden="true" />
@@ -187,7 +191,8 @@ export default function NavBar({ initialCategories, categoryError }: NavBarProps
 
           {/* Mobile Menu Panel - unchanged, but ensure error display is present if needed */}
           <Disclosure.Panel className="sm:hidden">
-            <div className="space-y-1 px-2 pb-3 pt-2">
+            <div className="space-y-3 px-2 pb-3 pt-2">
+              <SearchBar />
               {/* Ensure mobile navigation also uses the full list or has its own logic if different */}
               {navigation.map((item) => (
                 <Disclosure.Button

--- a/src/components/SearchBar.test.tsx
+++ b/src/components/SearchBar.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SearchBar from './SearchBar';
+
+const push = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+describe('SearchBar', () => {
+  it('submits query via router.push', () => {
+    render(<SearchBar />);
+    const input = screen.getByPlaceholderText('Search products…');
+    fireEvent.change(input, { target: { value: 'laptop' } });
+    fireEvent.submit(input.closest('form')!);
+    expect(push).toHaveBeenCalledWith('/search?q=laptop');
+  });
+});

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
+import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+
+export default function SearchBar() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [term, setTerm] = useState(searchParams.get('q') ?? '');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const handleShortcut = (e: KeyboardEvent) => {
+      if (e.key === '/' && document.activeElement !== inputRef.current) {
+        e.preventDefault();
+        inputRef.current?.focus();
+      }
+    };
+    window.addEventListener('keydown', handleShortcut);
+    return () => window.removeEventListener('keydown', handleShortcut);
+  }, []);
+
+  useEffect(() => {
+    setTerm(searchParams.get('q') ?? '');
+  }, [searchParams]);
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const q = term.trim();
+    if (q) {
+      router.push(`/search?q=${encodeURIComponent(q)}`);
+    }
+  };
+
+  return (
+    <form onSubmit={onSubmit} role="search" className="relative">
+      <label htmlFor="navbar-search" className="sr-only">
+        Search
+      </label>
+      <input
+        id="navbar-search"
+        ref={inputRef}
+        type="text"
+        className="w-full rounded-md border border-gray-300 bg-white bg-opacity-20 px-2 py-1 text-sm text-white placeholder-gray-300 focus:bg-opacity-100 focus:text-gray-900 focus:outline-none"
+        placeholder="Search products…"
+        value={term}
+        onChange={e => setTerm(e.target.value)}
+      />
+      <button
+        type="submit"
+        className="absolute right-1 top-1/2 -translate-y-1/2 text-gray-300 hover:text-white"
+        aria-label="Search"
+      >
+        <MagnifyingGlassIcon className="h-5 w-5" />
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- integrate a site-wide search bar
- expose keyboard shortcut `/` to focus the search box
- keep query in sync with the URL and submit via `router.push`
- mobile menu includes the same search field
- unit test verifying navigation on submit

## Testing
- `npm test` *(fails: vitest not found)*
- `npx lighthouse https://example.com` *(fails: Unable to connect to Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68547c1fedfc832a87bf8a8973ac49bd