### PR TITLE
Fix prerender errors on not-found pages

### DIFF
--- a/src/app/404.test.tsx
+++ b/src/app/404.test.tsx
@@ -2,12 +2,10 @@ import { render, screen } from '@testing-library/react';
 import NotFound404 from './404';
 import '@testing-library/jest-dom';
 
-vi.mock('@/components/SearchBar', () => ({
-  default: () => <input placeholder="Search products…" />,
-}));
-
 test('404 page renders without crash', () => {
   render(<NotFound404 />);
-  expect(screen.getByText('Page not found')).toBeInTheDocument();
-  expect(screen.getByPlaceholderText('Search products…')).toBeInTheDocument();
+  expect(screen.getByText('404 – Not found')).toBeInTheDocument();
+  const link = screen.getByRole('link', { name: /back to home/i });
+  expect(link).toBeInTheDocument();
+  expect(link).toHaveAttribute('href', '/');
 });

--- a/src/app/404.tsx
+++ b/src/app/404.tsx
@@ -1,16 +1,16 @@
-import { Suspense } from 'react';
-import SearchBar from '@/components/SearchBar';
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Page not found',
+};
 
 export default function NotFound404() {
   return (
-    <div className="container mx-auto px-4 py-12 text-center">
-      <h1 className="text-3xl font-bold mb-4">Page not found</h1>
-      <p className="mb-6">Sorry, we couldn&rsquo;t find what you were looking for.</p>
-      <Suspense fallback={null}>
-        <div className="max-w-sm mx-auto">
-          <SearchBar />
-        </div>
-      </Suspense>
-    </div>
+    <section className="mx-auto max-w-md py-24 text-center">
+      <h1 className="text-3xl font-bold mb-4">404 – Not found</h1>
+      <p className="mb-6">Sorry, we couldn&rsquo;t find that page.</p>
+      <Link href="/" className="btn-primary">Back to home</Link>
+    </section>
   );
 }

--- a/src/app/category/[slug]/_not-found.test.tsx
+++ b/src/app/category/[slug]/_not-found.test.tsx
@@ -2,12 +2,10 @@ import { render, screen } from '@testing-library/react';
 import CategoryNotFound from './_not-found';
 import '@testing-library/jest-dom';
 
-vi.mock('@/components/SearchBar', () => ({
-  default: () => <input placeholder="Search products…" />,
-}));
-
 test('category not found renders', () => {
   render(<CategoryNotFound />);
   expect(screen.getByText('Category not found')).toBeInTheDocument();
-  expect(screen.getByPlaceholderText('Search products…')).toBeInTheDocument();
+  const link = screen.getByRole('link', { name: /back to home/i });
+  expect(link).toBeInTheDocument();
+  expect(link).toHaveAttribute('href', '/');
 });

--- a/src/app/category/[slug]/_not-found.tsx
+++ b/src/app/category/[slug]/_not-found.tsx
@@ -1,16 +1,16 @@
-import { Suspense } from 'react';
-import SearchBar from '@/components/SearchBar';
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Category not found',
+};
 
 export default function CategoryNotFound() {
   return (
-    <div className="container mx-auto px-4 py-12 text-center">
+    <section className="mx-auto max-w-md py-24 text-center">
       <h1 className="text-2xl font-bold mb-4">Category not found</h1>
-      <p className="mb-6">We couldn&rsquo;t find that category.</p>
-      <Suspense fallback={null}>
-        <div className="max-w-sm mx-auto">
-          <SearchBar />
-        </div>
-      </Suspense>
-    </div>
+      <p className="mb-6">We couldn&apos;t find that category.</p>
+      <Link href="/" className="btn-primary">Back to home</Link>
+    </section>
   );
 }

--- a/src/app/not-found.test.tsx
+++ b/src/app/not-found.test.tsx
@@ -2,12 +2,10 @@ import { render, screen } from '@testing-library/react';
 import NotFound from './not-found';
 import '@testing-library/jest-dom';
 
-vi.mock('@/components/SearchBar', () => ({
-  default: () => <input placeholder="Search products…" />,
-}));
-
-test('renders not found message with search input', () => {
+test('renders not found message with home link', () => {
   render(<NotFound />);
-  expect(screen.getByText('Page not found')).toBeInTheDocument();
-  expect(screen.getByPlaceholderText('Search products…')).toBeInTheDocument();
+  expect(screen.getByText('404 – Not found')).toBeInTheDocument();
+  const link = screen.getByRole('link', { name: /back to home/i });
+  expect(link).toBeInTheDocument();
+  expect(link).toHaveAttribute('href', '/');
 });

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,16 +1,16 @@
-import { Suspense } from 'react';
-import SearchBar from '@/components/SearchBar';
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Page not found',
+};
 
 export default function NotFound() {
   return (
-    <div className="container mx-auto px-4 py-12 text-center">
-      <h1 className="text-3xl font-bold mb-4">Page not found</h1>
-      <p className="mb-6">Sorry, we couldn&apos;t find what you were looking for.</p>
-      <Suspense fallback={null}>
-        <div className="max-w-sm mx-auto">
-          <SearchBar />
-        </div>
-      </Suspense>
-    </div>
+    <section className="mx-auto max-w-md py-24 text-center">
+      <h1 className="text-3xl font-bold mb-4">404 – Not found</h1>
+      <p className="mb-6">Sorry, we couldn&apos;t find that page.</p>
+      <Link href="/" className="btn-primary">Back to home</Link>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary
- convert not-found pages to pure server components
- adjust tests for simplified markup

## Testing
- `pnpm exec vitest run`
- `pnpm run lint`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856a3df4198832a988208a8243f212a