### PR TITLE
Add Stripe checkout flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,5 @@ NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=changeme
 STRIPE_SECRET_KEY=sk_test_yourkey
 STRIPE_PUBLISHABLE_KEY=pk_test_yourkey
+# optional until webhook route is added
 STRIPE_WEBHOOK_SECRET=whsec_yourkey

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 # NextAuth configuration
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=changeme
+STRIPE_SECRET_KEY=sk_test_yourkey
+STRIPE_PUBLISHABLE_KEY=pk_test_yourkey

--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=changeme
 STRIPE_SECRET_KEY=sk_test_yourkey
 STRIPE_PUBLISHABLE_KEY=pk_test_yourkey
+STRIPE_WEBHOOK_SECRET=whsec_yourkey

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ To enable the checkout flow in production, set the following environment variabl
 
 - `STRIPE_SECRET_KEY`
 - `STRIPE_PUBLISHABLE_KEY`
-- `STRIPE_WEBHOOK_SECRET`
+- `STRIPE_WEBHOOK_SECRET` *(optional until webhook route is added)*
+
+The webhook secret will be required once we implement webhook handling.
 
 
 Here’s the updated `README.md` section you can append under a new heading, such as **"Development Notes and Practices"**:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ The easiest way to deploy your Next.js app is to use the [Vercel Platform](https
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/pages/building-your-application/deploying) for more details.
 
+## Deploying with Stripe
+
+To enable the checkout flow in production, set the following environment variables in Vercel (or `.env.local` for local testing):
+
+- `STRIPE_SECRET_KEY`
+- `STRIPE_PUBLISHABLE_KEY`
+- `STRIPE_WEBHOOK_SECRET`
+
+
 Here’s the updated `README.md` section you can append under a new heading, such as **"Development Notes and Practices"**:
 
 ---

--- a/__tests__/checkout-api.test.ts
+++ b/__tests__/checkout-api.test.ts
@@ -1,13 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
 import { POST } from '../src/app/api/checkout/route';
 
-vi.mock('stripe', () => {
-  return {
-    default: vi.fn().mockImplementation(() => ({
-      checkout: { sessions: { create: vi.fn(() => Promise.resolve({ url: 'https://stripe.test/checkout' })) } },
-    })),
-  };
-});
+vi.mock('../src/lib/getStripe', () => ({
+  stripe: {
+    checkout: { sessions: { create: vi.fn(() => Promise.resolve({ url: 'https://stripe.test/checkout' })) } },
+  },
+}));
 
 vi.mock('../src/bff/adapters/dummyjson', () => ({
   fetchProductById: vi.fn(async (id: number) => ({ id, title: 'Test', price: 10, thumbnail: 'img' })),

--- a/__tests__/checkout-api.test.ts
+++ b/__tests__/checkout-api.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi } from 'vitest';
 import { POST } from '../src/app/api/checkout/route';
 
-vi.mock('../src/lib/getStripe', () => ({
-  stripe: {
-    checkout: { sessions: { create: vi.fn(() => Promise.resolve({ url: 'https://stripe.test/checkout' })) } },
-  },
-}));
+vi.mock('../src/lib/stripe', () => {
+  return {
+    getStripe: () => ({
+      checkout: { sessions: { create: vi.fn(() => Promise.resolve({ url: 'https://stripe.test/checkout' })) } },
+    }),
+  };
+});
 
 vi.mock('../src/bff/adapters/dummyjson', () => ({
   fetchProductById: vi.fn(async (id: number) => ({ id, title: 'Test', price: 10, thumbnail: 'img' })),

--- a/__tests__/checkout-api.test.ts
+++ b/__tests__/checkout-api.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+import { POST } from '../src/app/api/checkout/route';
+
+vi.mock('stripe', () => {
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      checkout: { sessions: { create: vi.fn(() => Promise.resolve({ url: 'https://stripe.test/checkout' })) } },
+    })),
+  };
+});
+
+vi.mock('../src/bff/adapters/dummyjson', () => ({
+  fetchProductById: vi.fn(async (id: number) => ({ id, title: 'Test', price: 10, thumbnail: 'img' })),
+}));
+
+describe('POST /api/checkout', () => {
+  it('returns checkout url', async () => {
+    const req = {
+      json: async () => ({ items: [{ productId: 1, quantity: 2 }] }),
+      headers: new Headers({ origin: 'http://localhost:3000' }),
+      url: 'http://localhost:3000/api/checkout',
+    } as unknown as Request;
+
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.url).toBe('https://stripe.test/checkout');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hot-toast": "*",
+    "stripe": "^18.2.1",
     "use-debounce": "^10.0.5",
     "zod": "*",
     "zustand": "^4.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       react-hot-toast:
         specifier: '*'
         version: 2.5.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      stripe:
+        specifier: ^18.2.1
+        version: 18.2.1(@types/node@20.19.1)
       use-debounce:
         specifier: ^10.0.5
         version: 10.0.5(react@19.1.0)
@@ -3071,6 +3074,10 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.14.0:
+    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+    engines: {node: '>=0.6'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -3334,6 +3341,15 @@ packages:
 
   strip-literal@3.0.0:
     resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
+
+  stripe@18.2.1:
+    resolution: {integrity: sha512-GwB1B7WSwEBzW4dilgyJruUYhbGMscrwuyHsPUmSRKrGHZ5poSh2oU9XKdii5BFVJzXHn35geRvGJ6R8bYcp8w==}
+    engines: {node: '>=12.*'}
+    peerDependencies:
+      '@types/node': '>=12.x.x'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -6979,6 +6995,10 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qs@6.14.0:
+    dependencies:
+      side-channel: 1.1.0
+
   queue-microtask@1.2.3: {}
 
   react-dom@19.1.0(react@19.1.0):
@@ -7333,6 +7353,12 @@ snapshots:
   strip-literal@3.0.0:
     dependencies:
       js-tokens: 9.0.1
+
+  stripe@18.2.1(@types/node@20.19.1):
+    dependencies:
+      qs: 6.14.0
+    optionalDependencies:
+      '@types/node': 20.19.1
 
   styled-jsx@5.1.6(@babel/core@7.27.4)(react@19.1.0):
     dependencies:

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { fetchProductById } from '@/bff/adapters/dummyjson';
 import type Stripe from 'stripe';
-import { stripe } from '@/lib/getStripe';
+import { getStripe } from '@/lib/stripe';
 
 export const dynamic = 'force-dynamic';
 
@@ -16,6 +16,17 @@ export async function POST(request: Request) {
     body = await request.json();
   } catch {
     return NextResponse.json({ message: 'Invalid JSON' }, { status: 400 });
+  }
+
+  let stripe: Stripe;
+  try {
+    stripe = getStripe();
+  } catch (err) {
+    console.error('[checkout] Stripe config error', err);
+    return NextResponse.json(
+      { error: 'Stripe not configured' },
+      { status: 500 },
+    );
   }
 
   const items = body.items;

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from 'next/server';
 import { fetchProductById } from '@/bff/adapters/dummyjson';
 import type Stripe from 'stripe';
+import { stripe } from '@/lib/getStripe';
+
+export const dynamic = 'force-dynamic';
 
 interface Item {
   productId: number;
@@ -20,10 +23,6 @@ export async function POST(request: Request) {
     return NextResponse.json({ message: 'No items' }, { status: 400 });
   }
 
-  const { default: Stripe } = await import('stripe');
-  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
-    apiVersion: '2024-04-10',
-  });
 
   const line_items: Stripe.Checkout.SessionCreateParams.LineItem[] = [];
   for (const item of items) {

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from 'next/server';
+import { fetchProductById } from '@/bff/adapters/dummyjson';
+import type Stripe from 'stripe';
+
+interface Item {
+  productId: number;
+  quantity: number;
+}
+
+export async function POST(request: Request) {
+  let body: { items?: Item[] };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ message: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const items = body.items;
+  if (!items || !Array.isArray(items) || items.length === 0) {
+    return NextResponse.json({ message: 'No items' }, { status: 400 });
+  }
+
+  const { default: Stripe } = await import('stripe');
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
+    apiVersion: '2024-04-10',
+  });
+
+  const line_items: Stripe.Checkout.SessionCreateParams.LineItem[] = [];
+  for (const item of items) {
+    const product = await fetchProductById(item.productId);
+    if (!product) {
+      return NextResponse.json({ message: `Product ${item.productId} not found` }, { status: 400 });
+    }
+    line_items.push({
+      price_data: {
+        currency: 'usd',
+        unit_amount: Math.round(product.price * 100),
+        product_data: {
+          name: product.title,
+          images: product.thumbnail ? [product.thumbnail] : undefined,
+        },
+      },
+      quantity: item.quantity,
+    });
+  }
+
+  const origin = request.headers.get('origin') || new URL(request.url).origin;
+
+  const session = await stripe.checkout.sessions.create({
+    mode: 'payment',
+    line_items,
+    success_url: `${origin}/order/success?session_id={CHECKOUT_SESSION_ID}`,
+    cancel_url: `${origin}/cart?canceled=1`,
+    shipping_options: [
+      {
+        shipping_rate_data: {
+          type: 'fixed_amount',
+          fixed_amount: { amount: 0, currency: 'usd' },
+          display_name: 'Free shipping',
+          delivery_estimate: {
+            minimum: { unit: 'business_day', value: 5 },
+            maximum: { unit: 'business_day', value: 7 },
+          },
+        },
+      },
+    ],
+    automatic_tax: { enabled: false },
+  });
+
+  return NextResponse.json({ url: session.url });
+}

--- a/src/app/api/checkout/session/route.ts
+++ b/src/app/api/checkout/session/route.ts
@@ -1,4 +1,7 @@
 import { NextResponse } from 'next/server';
+import { stripe } from '@/lib/getStripe';
+
+export const dynamic = 'force-dynamic';
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -7,10 +10,6 @@ export async function GET(request: Request) {
     return NextResponse.json({ message: 'session_id required' }, { status: 400 });
   }
 
-  const { default: Stripe } = await import('stripe');
-  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
-    apiVersion: '2024-04-10',
-  });
 
   try {
     const session = await stripe.checkout.sessions.retrieve(sessionId);

--- a/src/app/api/checkout/session/route.ts
+++ b/src/app/api/checkout/session/route.ts
@@ -1,9 +1,19 @@
 import { NextResponse } from 'next/server';
-import { stripe } from '@/lib/getStripe';
+import { getStripe } from '@/lib/stripe';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(request: Request) {
+  let stripe: import('stripe').default;
+  try {
+    stripe = getStripe();
+  } catch (err) {
+    console.error('[checkout/session] Stripe config error', err);
+    return NextResponse.json(
+      { message: 'Stripe not configured' },
+      { status: 500 },
+    );
+  }
   const { searchParams } = new URL(request.url);
   const sessionId = searchParams.get('session_id');
   if (!sessionId) {

--- a/src/app/api/checkout/session/route.ts
+++ b/src/app/api/checkout/session/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const sessionId = searchParams.get('session_id');
+  if (!sessionId) {
+    return NextResponse.json({ message: 'session_id required' }, { status: 400 });
+  }
+
+  const { default: Stripe } = await import('stripe');
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
+    apiVersion: '2024-04-10',
+  });
+
+  try {
+    const session = await stripe.checkout.sessions.retrieve(sessionId);
+    return NextResponse.json(session);
+  } catch (err) {
+    console.error('Stripe retrieve error', err);
+    return NextResponse.json({ message: 'Unable to retrieve session' }, { status: 500 });
+  }
+}

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import Image from 'next/image'; // For better image handling
 import { TrashIcon, PlusIcon, MinusIcon } from '@heroicons/react/24/outline';
 import toast from 'react-hot-toast';
+import React from 'react';
 
 export default function CartPage() {
   // Subscribe to cart store state and actions
@@ -37,6 +38,32 @@ export default function CartPage() {
     // Stub handler for now
     toast.info('"Request Quote" feature coming soon!');
     // In a real app, this might clear the cart and redirect to a quote form or confirmation page.
+  };
+
+  const [checkingOut, setCheckingOut] = React.useState(false);
+
+  const handleCheckout = async () => {
+    setCheckingOut(true);
+    try {
+      const response = await fetch('/api/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          items: items.map((i) => ({ productId: i.product.id, quantity: i.quantity })),
+        }),
+      });
+      const data = await response.json();
+      if (response.ok && data.url) {
+        window.location.href = data.url as string;
+      } else {
+        toast.error('Checkout failed');
+      }
+    } catch (err) {
+      console.error(err);
+      toast.error('Checkout failed');
+    } finally {
+      setCheckingOut(false);
+    }
   };
 
   return (
@@ -171,6 +198,18 @@ export default function CartPage() {
                   Request Quote (Stub)
                 </button>
               </div>
+              {items.length > 0 && (
+                <div className="mt-4">
+                  <button
+                    type="button"
+                    onClick={handleCheckout}
+                    disabled={checkingOut}
+                    className="w-full rounded-md border border-transparent bg-green-600 px-4 py-3 text-base font-medium text-white shadow-sm hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-gray-50 disabled:opacity-50"
+                  >
+                    {checkingOut ? 'Processing…' : 'Checkout'}
+                  </button>
+                </div>
+              )}
               <div className="mt-4">
                  <button
                     type="button"

--- a/src/app/order/success/page.tsx
+++ b/src/app/order/success/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from 'react';
+import OrderSuccessClient from './success-client';
+
+export default function OrderSuccessPage() {
+  return (
+    <Suspense>
+      <OrderSuccessClient />
+    </Suspense>
+  );
+}

--- a/src/app/order/success/success-client.tsx
+++ b/src/app/order/success/success-client.tsx
@@ -1,0 +1,46 @@
+'use client';
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { getCheckoutSession } from '@/bff/services/stripe';
+import type { CheckoutSession } from '@/types/order';
+
+export default function OrderSuccessClient() {
+  const params = useSearchParams();
+  const sessionId = params.get('session_id');
+  const [session, setSession] = useState<CheckoutSession | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!sessionId) return;
+    setLoading(true);
+    getCheckoutSession(sessionId)
+      .then((s) => {
+        setSession(s);
+        setError(null);
+      })
+      .catch(() => setError('Failed to load session'))
+      .finally(() => setLoading(false));
+  }, [sessionId]);
+
+  if (!sessionId) {
+    return <div className="container mx-auto px-4 py-8 text-center">Missing session ID.</div>;
+  }
+
+  if (loading) {
+    return <div className="container mx-auto px-4 py-8 text-center">Loading...</div>;
+  }
+
+  if (error || !session) {
+    return <div className="container mx-auto px-4 py-8 text-center">{error || 'No session found'}.</div>;
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 text-center">
+      <h1 className="text-2xl font-semibold mb-4">Thanks {session.customer?.name || 'customer'}!</h1>
+      <p className="mb-6">Order #{session.id} confirmed.</p>
+      <Link href="/" className="text-blue-600 hover:underline">Back to store</Link>
+    </div>
+  );
+}

--- a/src/bff/services/stripe.ts
+++ b/src/bff/services/stripe.ts
@@ -1,0 +1,9 @@
+import type { CheckoutSession } from '@/types/order';
+
+export async function getCheckoutSession(sessionId: string): Promise<CheckoutSession> {
+  const res = await fetch(`/api/checkout/session?session_id=${sessionId}`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch checkout session');
+  }
+  return res.json();
+}

--- a/src/lib/getStripe.ts
+++ b/src/lib/getStripe.ts
@@ -1,0 +1,5 @@
+import Stripe from 'stripe';
+
+export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: '2024-04-10',
+});

--- a/src/lib/getStripe.ts
+++ b/src/lib/getStripe.ts
@@ -1,5 +1,0 @@
-import Stripe from 'stripe';
-
-export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: '2024-04-10',
-});

--- a/src/lib/stripe.test.ts
+++ b/src/lib/stripe.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { validateStripeEnv } from './stripe';
+
+const originalEnv = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+describe('validateStripeEnv', () => {
+  it('throws when required env vars are missing', () => {
+    process.env = {} as any;
+    expect(() => validateStripeEnv()).toThrow();
+  });
+});

--- a/src/lib/stripe.test.ts
+++ b/src/lib/stripe.test.ts
@@ -12,4 +12,12 @@ describe('validateStripeEnv', () => {
     process.env = {} as any;
     expect(() => validateStripeEnv()).toThrow();
   });
+
+  it('allows missing webhook secret', () => {
+    process.env = {
+      STRIPE_SECRET_KEY: 'sk_test_123',
+      STRIPE_PUBLISHABLE_KEY: 'pk_test_123',
+    } as any;
+    expect(() => validateStripeEnv()).not.toThrow();
+  });
 });

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,8 +1,0 @@
-import Stripe from 'stripe';
-
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
-  apiVersion: '2024-04-10',
-});
-
-export default stripe;
-export { stripe };

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,0 +1,8 @@
+import Stripe from 'stripe';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
+  apiVersion: '2024-04-10',
+});
+
+export default stripe;
+export { stripe };

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 const EnvSchema = z.object({
   STRIPE_SECRET_KEY: z.string().min(1),
   STRIPE_PUBLISHABLE_KEY: z.string().min(1),
-  STRIPE_WEBHOOK_SECRET: z.string().min(1),
+  STRIPE_WEBHOOK_SECRET: z.string().min(1).optional(),
 });
 
 export type StripeEnv = z.infer<typeof EnvSchema>;

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,0 +1,24 @@
+import Stripe from 'stripe';
+import { z } from 'zod';
+
+const EnvSchema = z.object({
+  STRIPE_SECRET_KEY: z.string().min(1),
+  STRIPE_PUBLISHABLE_KEY: z.string().min(1),
+  STRIPE_WEBHOOK_SECRET: z.string().min(1),
+});
+
+export type StripeEnv = z.infer<typeof EnvSchema>;
+
+export function validateStripeEnv(env: NodeJS.ProcessEnv = process.env): StripeEnv {
+  return EnvSchema.parse(env);
+}
+
+let stripeInstance: Stripe | null = null;
+
+export function getStripe(): Stripe {
+  if (!stripeInstance) {
+    const { STRIPE_SECRET_KEY } = validateStripeEnv();
+    stripeInstance = new Stripe(STRIPE_SECRET_KEY, { apiVersion: '2023-10-16' });
+  }
+  return stripeInstance;
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -23,3 +23,5 @@ export type Product = {
   imageUrl: string;
   createdAt: string;
 };
+
+export type { CartItem, CheckoutSession } from './order';

--- a/types/order.ts
+++ b/types/order.ts
@@ -1,0 +1,10 @@
+export interface CartItem {
+  productId: number;
+  quantity: number;
+}
+
+export interface CheckoutSession {
+  id: string;
+  url?: string;
+  customer: { name?: string | null } | null;
+}


### PR DESCRIPTION
## Summary
- create serverless endpoint to open Stripe Checkout session
- add helper and API for retrieving Checkout session
- add checkout button to cart page
- implement order success page
- add stripe util and types
- include integration test

## Testing
- `pnpm lint`
- `pnpm test --run`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_6859661709a4832a9ad731f3331cc987