### PR TITLE
Add wishlist feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@next-auth/prisma-adapter": "1.0.7",
     "applicationinsights": "^3.7.0",
     "debug": "^4.3.4",
+    "lucide-react": "^0.523.0",
     "next-auth": "^4.24.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       debug:
         specifier: ^4.3.4
         version: 4.4.1
+      lucide-react:
+        specifier: ^0.523.0
+        version: 0.523.0(react@19.1.0)
       next-auth:
         specifier: ^4.24.6
         version: 4.24.11(next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2724,6 +2727,11 @@ packages:
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
+
+  lucide-react@0.523.0:
+    resolution: {integrity: sha512-rUjQoy7egZT9XYVXBK1je9ckBnNp7qzRZOhLQx5RcEp2dCGlXo+mv6vf7Am4LimEcFBJIIZzSGfgTqc9QCrPSw==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -6659,6 +6667,10 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+
+  lucide-react@0.523.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   lz-string@1.5.0: {}
 

--- a/src/app/product/[slug]/page.tsx
+++ b/src/app/product/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { useParams } from 'next/navigation'; // useParams for client component
 import ProductGallery from '@/components/ProductGallery'; // Changed from Gallery to ProductGallery
 import PriceBox from '@/components/PriceBox';
 import CopyLinkButton from '@/components/CopyLinkButton';
+import WishlistButton from '@/components/WishlistButton';
 import { useCartStore } from '@/stores/useCartStore'; // Import cart store
 import toast from 'react-hot-toast'; // For feedback
 import { useEffect, useState } from 'react'; // For client-side data fetching
@@ -149,6 +150,7 @@ export default function ProductPage() {
             >
               {product.stock && product.stock > 0 ? 'Add to Cart' : 'Out of Stock'}
             </button>
+            <WishlistButton product={product} />
             <CopyLinkButton />
           </div>
         </div>

--- a/src/app/wishlist/page.tsx
+++ b/src/app/wishlist/page.tsx
@@ -1,0 +1,67 @@
+'use client';
+import Link from 'next/link';
+import Image from 'next/image';
+import { useWishlistStore } from '@/store/wishlist';
+import { useCartStore } from '@/stores/useCartStore';
+import { EMPTY_WISHLIST_MESSAGE, CONTINUE_SHOPPING } from '@/constants/text';
+import { HeartOff } from 'lucide-react';
+
+export default function WishlistPage() {
+  const items = useWishlistStore((s) => s.items);
+  const remove = useWishlistStore((s) => s.remove);
+  const clear = useWishlistStore((s) => s.clear);
+  const addToCart = useCartStore((s) => s.addItem);
+
+  const list = Object.values(items);
+
+  if (list.length === 0) {
+    return (
+      <div className="text-center py-10">
+        <p className="text-xl text-gray-700 mb-4">{EMPTY_WISHLIST_MESSAGE}</p>
+        <Link href="/" className="text-lg text-blue-600 hover:text-blue-800 font-medium">
+          {CONTINUE_SHOPPING}
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {list.map((product) => (
+        <div key={product.id} className="flex items-center border p-4 rounded-md shadow bg-white">
+          <Image
+            src={product.thumbnail || '/placeholder-image.webp'}
+            alt={product.title}
+            width={80}
+            height={80}
+            className="rounded-md mr-4 object-cover"
+          />
+          <div className="flex-1">
+            <h3 className="text-lg font-semibold">{product.title}</h3>
+            <p className="text-sm text-gray-500">${(product.effectivePrice?.amount ?? product.price).toFixed(2)}</p>
+          </div>
+          <button
+            onClick={() => addToCart(product, 1)}
+            className="mr-3 rounded-md bg-blue-600 px-3 py-2 text-white text-sm hover:bg-blue-700"
+          >
+            Add to cart
+          </button>
+          <button
+            onClick={() => remove(product.id)}
+            className="text-gray-500 hover:text-red-600"
+            aria-label="Remove from wishlist"
+          >
+            <HeartOff className="h-5 w-5" />
+          </button>
+        </div>
+      ))}
+      {list.length > 1 && (
+        <div className="text-right">
+          <button onClick={clear} className="text-sm text-red-600 hover:text-red-800">
+            Clear Wishlist
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -4,12 +4,14 @@
 import Image from 'next/image';
 import { Disclosure, Menu, Transition } from '@headlessui/react';
 import { Bars3Icon, XMarkIcon, UserCircleIcon, ShoppingCartIcon } from '@heroicons/react/24/outline'; // Keep outline or solid consistently
+import { Heart } from 'lucide-react';
 import SearchBar from './SearchBar';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useSession, signOut } from 'next-auth/react';
 import { Fragment } from 'react';
 import { useCartStore } from '@/stores/useCartStore'; // Import cart store
+import { useWishlistStore } from '@/store/wishlist';
 import { useHasMounted } from '@/hooks/useHasMounted'; // Import useHasMounted
 
 interface CategoryNavItem {
@@ -33,6 +35,7 @@ export default function NavBar({ initialCategories, categoryError }: NavBarProps
 
   // Get total items from cart store for the badge
   const totalCartItems = useCartStore((state) => state.getTotalItems());
+  const wishlistCount = Object.keys(useWishlistStore((s) => s.items)).length;
 
   const MAX_VISIBLE_CATEGORIES = 5;
 
@@ -144,6 +147,15 @@ export default function NavBar({ initialCategories, categoryError }: NavBarProps
                   {hasMounted && totalCartItems > 0 && (
                     <span className="absolute -top-2 -right-2 flex h-5 w-5 items-center justify-center rounded-full bg-red-500 text-xs font-bold text-white">
                       {totalCartItems}
+                    </span>
+                  )}
+                </Link>
+                <Link href="/wishlist" className="relative rounded-full bg-gray-800 p-1 text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800" title="View Wishlist">
+                  <span className="sr-only">View Wishlist</span>
+                  <Heart className="h-6 w-6" aria-hidden="true" />
+                  {hasMounted && wishlistCount > 0 && (
+                    <span className="absolute -top-2 -right-2 flex h-5 w-5 items-center justify-center rounded-full bg-red-500 text-xs font-bold text-white">
+                      {wishlistCount}
                     </span>
                   )}
                 </Link>

--- a/src/components/WishlistButton.test.tsx
+++ b/src/components/WishlistButton.test.tsx
@@ -1,0 +1,39 @@
+// src/components/WishlistButton.test.tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, beforeEach } from 'vitest';
+import WishlistButton from './WishlistButton';
+import { ProductSchema } from '@/bff/types';
+import { z } from 'zod';
+import { useWishlistStore } from '@/store/wishlist';
+import { ADD_TO_WISHLIST, SAVED_TO_WISHLIST } from '@/constants/text';
+
+const mockProduct: z.infer<typeof ProductSchema> = {
+  id: 1,
+  title: 'Test',
+  price: 5,
+  description: 'd',
+  category: { name: 'Cat', slug: 'cat' },
+  slug: 'test',
+  images: [],
+  thumbnail: '',
+  rating: 4,
+};
+
+beforeEach(() => {
+  useWishlistStore.setState(useWishlistStore.getInitialState(), true);
+});
+
+describe('WishlistButton', () => {
+  it('toggles label and icon', () => {
+    render(<WishlistButton product={mockProduct} />);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveTextContent(ADD_TO_WISHLIST);
+    const svg = btn.querySelector('svg');
+    expect(svg).toHaveAttribute('fill', 'none');
+
+    fireEvent.click(btn);
+    expect(btn).toHaveTextContent(SAVED_TO_WISHLIST);
+    expect(svg).toHaveAttribute('fill', 'currentColor');
+  });
+});

--- a/src/components/WishlistButton.tsx
+++ b/src/components/WishlistButton.tsx
@@ -1,0 +1,32 @@
+'use client';
+import { Heart } from 'lucide-react';
+import { useWishlistStore } from '@/store/wishlist';
+import { z } from 'zod';
+import { ProductSchema } from '@/bff/types';
+import { ADD_TO_WISHLIST, SAVED_TO_WISHLIST } from '@/constants/text';
+
+export type Product = z.infer<typeof ProductSchema>;
+
+export default function WishlistButton({ product }: { product: Product }) {
+  const items = useWishlistStore((s) => s.items);
+  const add = useWishlistStore((s) => s.add);
+  const remove = useWishlistStore((s) => s.remove);
+
+  const saved = !!items[product.id];
+  const toggle = () => (saved ? remove(product.id) : add(product));
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      className="mt-2 flex items-center justify-center w-full border rounded-md py-2 text-sm font-medium text-gray-700 hover:bg-gray-100"
+      aria-label={saved ? 'Remove from wishlist' : 'Save to wishlist'}
+    >
+      <Heart
+        className="mr-2 h-5 w-5"
+        fill={saved ? 'currentColor' : 'none'}
+      />
+      {saved ? SAVED_TO_WISHLIST : ADD_TO_WISHLIST}
+    </button>
+  );
+}

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -1,0 +1,4 @@
+export const ADD_TO_WISHLIST = '♥ Save to wishlist';
+export const SAVED_TO_WISHLIST = 'Saved';
+export const EMPTY_WISHLIST_MESSAGE = 'Your wishlist is empty.';
+export const CONTINUE_SHOPPING = 'Continue Shopping →';

--- a/src/store/WishlistStore.test.ts
+++ b/src/store/WishlistStore.test.ts
@@ -1,0 +1,39 @@
+// src/store/WishlistStore.test.ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useWishlistStore } from './wishlist';
+import { ProductSchema } from '@/bff/types';
+import { z } from 'zod';
+
+const mockProduct: z.infer<typeof ProductSchema> = {
+  id: 1,
+  title: 'Test Product',
+  price: 10,
+  description: 'desc',
+  category: { name: 'Cat', slug: 'cat' },
+  slug: 'test-product',
+  images: [],
+  thumbnail: '',
+  rating: 4,
+};
+
+beforeEach(() => {
+  useWishlistStore.setState(useWishlistStore.getInitialState(), true);
+  localStorage.clear();
+  if (vi.isMockFunction(localStorage.setItem)) localStorage.setItem.mockClear();
+});
+
+describe('Wishlist store persistence', () => {
+  it('persists items after re-init', () => {
+    useWishlistStore.getState().add(mockProduct);
+    expect(useWishlistStore.getState().items[mockProduct.id]).toBeDefined();
+
+    const stored = localStorage.getItem('beta-wishlist-v1');
+    expect(stored).toBeTruthy();
+
+    useWishlistStore.setState(useWishlistStore.getInitialState(), true);
+    const parsed = JSON.parse(stored as string);
+    useWishlistStore.setState(parsed.state);
+
+    expect(useWishlistStore.getState().items[mockProduct.id]).toBeDefined();
+  });
+});

--- a/src/store/wishlist.ts
+++ b/src/store/wishlist.ts
@@ -1,0 +1,39 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import { z } from 'zod';
+import { ProductSchema } from '@/bff/types';
+
+export type Product = z.infer<typeof ProductSchema>;
+
+interface WishlistState {
+  items: Record<number, Product>;
+  add: (product: Product) => void;
+  remove: (productId: number) => void;
+  clear: () => void;
+}
+
+const initialState: Pick<WishlistState, 'items'> = {
+  items: {},
+};
+
+export const useWishlistStore = create<WishlistState>()(
+  persist(
+    (set) => ({
+      ...initialState,
+      add: (product) =>
+        set((state) => ({ items: { ...state.items, [product.id]: product } })),
+      remove: (productId) =>
+        set((state) => {
+          const newItems = { ...state.items };
+          delete newItems[productId];
+          return { items: newItems };
+        }),
+      clear: () => set({ ...initialState }),
+    }),
+    {
+      name: 'beta-wishlist-v1',
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+);
+


### PR DESCRIPTION
## Summary
- add a persistent wishlist store
- display wishlist controls and badge in the UI
- create wishlist page
- add texts and tests for wishlist
- include lucide-react dependency

## Testing
- `pnpm run build`
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_685bdb3fda4c832ab7848673909fd104