### PR TITLE
Improve product carousel a11y

### DIFF
--- a/__tests__/components/PopularProductsCarouselClient.test.tsx
+++ b/__tests__/components/PopularProductsCarouselClient.test.tsx
@@ -10,6 +10,7 @@ const mockProducts: PopularProduct[] = Array.from({ length: 5 }).map((_, i) => (
   discountPercentage: 0,
   thumbnail: `https://example.com/p${i + 1}.jpg`,
   rating: 5 - i * 0.2,
+  blurDataURL: 'data:image/png;base64,AAA',
 }));
 
 describe('PopularProductsCarouselClient', () => {
@@ -24,5 +25,16 @@ describe('PopularProductsCarouselClient', () => {
     });
     const titleLinks = screen.getAllByRole('link', { name: /Product/ });
     expect(titleLinks).toHaveLength(5);
+  });
+
+  it('disables arrows when products do not exceed visible cards', () => {
+    const few = mockProducts.slice(0, 3);
+    render(<PopularProductsCarouselClient products={few} />);
+    expect(
+      screen.getByRole('button', { name: /previous products/i })
+    ).toHaveAttribute('aria-disabled', 'true');
+    expect(
+      screen.getByRole('button', { name: /next products/i })
+    ).toHaveAttribute('aria-disabled', 'true');
   });
 });

--- a/src/components/PopularProductsCarouselClient.tsx
+++ b/src/components/PopularProductsCarouselClient.tsx
@@ -6,36 +6,43 @@ import ProductCard, { type Product } from './ProductCard';
 import { slugify } from '@/lib/utils';
 
 type Props = { products: PopularProduct[] };
+const visibleCards = 3;
 
 export default function PopularProductsCarouselClient({ products }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [canPrev, setCanPrev] = useState(false);
-  const [canNext, setCanNext] = useState(false);
-
-  const updateArrows = () => {
-    const el = containerRef.current;
-    if (!el) return;
-    setCanPrev(el.scrollLeft > 0);
-    setCanNext(el.scrollWidth > el.clientWidth + el.scrollLeft + 1);
-  };
+  const [canNext, setCanNext] = useState(products.length > visibleCards);
 
   useEffect(() => {
-    updateArrows();
+    if (products.length <= visibleCards) {
+      setCanPrev(false);
+      setCanNext(false);
+      return;
+    }
     const el = containerRef.current;
     if (!el) return;
-    el.addEventListener('scroll', updateArrows);
-    window.addEventListener('resize', updateArrows);
-    return () => {
-      el.removeEventListener('scroll', updateArrows);
-      window.removeEventListener('resize', updateArrows);
-    };
-  }, []);
+    const first = el.firstElementChild;
+    const last = el.lastElementChild;
+    if (!first || !last) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.target === first) setCanPrev(!entry.isIntersecting);
+          if (entry.target === last) setCanNext(!entry.isIntersecting);
+        });
+      },
+      { root: el, threshold: 0.9 }
+    );
+    observer.observe(first);
+    observer.observe(last);
+    return () => observer.disconnect();
+  }, [products.length]);
 
   const scrollBy = (offset: number) => {
     containerRef.current?.scrollBy({ left: offset, behavior: 'smooth' });
   };
 
-  const normalize = (p: PopularProduct): Product => ({
+  const normalize = (p: PopularProduct): Product & { blurDataURL: string } => ({
     id: p.id,
     title: p.title,
     slug: slugify(p.title),
@@ -47,6 +54,7 @@ export default function PopularProductsCarouselClient({ products }: Props) {
     brand: '',
     category: { name: '', slug: '' },
     thumbnail: p.thumbnail,
+    blurDataURL: p.blurDataURL,
     images: [],
     effectivePrice:
       p.discountPercentage > 0
@@ -67,28 +75,26 @@ export default function PopularProductsCarouselClient({ products }: Props) {
           </div>
         ))}
       </div>
-      {canPrev && (
-        <button
-          type="button"
-          onClick={() => scrollBy(-250)}
-          aria-controls="popular-carousel"
-          className="hidden md:flex absolute left-0 top-1/2 -translate-y-1/2 bg-white dark:bg-gray-700 p-2 rounded-full shadow"
-        >
-          <span className="sr-only">Previous products</span>
-          <ChevronLeft className="h-5 w-5" />
-        </button>
-      )}
-      {canNext && (
-        <button
-          type="button"
-          onClick={() => scrollBy(250)}
-          aria-controls="popular-carousel"
-          className="hidden md:flex absolute right-0 top-1/2 -translate-y-1/2 bg-white dark:bg-gray-700 p-2 rounded-full shadow"
-        >
-          <span className="sr-only">Next products</span>
-          <ChevronRight className="h-5 w-5" />
-        </button>
-      )}
+      <button
+        type="button"
+        onClick={() => scrollBy(-250)}
+        aria-controls="popular-carousel"
+        aria-disabled={!canPrev}
+        className={`hidden md:flex absolute left-0 top-1/2 -translate-y-1/2 bg-white dark:bg-gray-700 p-2 rounded-full shadow ${!canPrev ? 'opacity-40 pointer-events-none' : ''}`}
+      >
+        <span className="sr-only">Previous products</span>
+        <ChevronLeft className="h-5 w-5" />
+      </button>
+      <button
+        type="button"
+        onClick={() => scrollBy(250)}
+        aria-controls="popular-carousel"
+        aria-disabled={!canNext}
+        className={`hidden md:flex absolute right-0 top-1/2 -translate-y-1/2 bg-white dark:bg-gray-700 p-2 rounded-full shadow ${!canNext ? 'opacity-40 pointer-events-none' : ''}`}
+      >
+        <span className="sr-only">Next products</span>
+        <ChevronRight className="h-5 w-5" />
+      </button>
     </div>
   );
 }

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -8,7 +8,7 @@ export type Product = z.infer<typeof ProductSchema>;
 import { highlight } from '@/utils/highlight';
 
 interface ProductCardProps {
-  product: Product;
+  product: Product & { blurDataURL?: string };
   highlightTerm?: string;
 }
 
@@ -25,6 +25,8 @@ export default function ProductCard({ product, highlightTerm }: ProductCardProps
                 fill
                 sizes="(max-width: 640px) 100vw, (max-width: 768px) 50vw, 33vw"
                 className="object-cover object-center group-hover:opacity-75"
+                placeholder="blur"
+                blurDataURL={product.blurDataURL}
               />
             </div>
           )}

--- a/src/utils/getPopularProducts.ts
+++ b/src/utils/getPopularProducts.ts
@@ -5,6 +5,7 @@ export interface PopularProduct {
   discountPercentage: number;
   thumbnail: string;
   rating: number;
+  blurDataURL: string;
 }
 
 export async function getPopularProducts(): Promise<PopularProduct[]> {
@@ -18,8 +19,24 @@ export async function getPopularProducts(): Promise<PopularProduct[]> {
     throw new Error('Failed to fetch popular products');
   }
   const data = await res.json();
-  const products: PopularProduct[] = Array.isArray(data.products)
+  const products: Omit<PopularProduct, 'blurDataURL'>[] = Array.isArray(
+    data.products
+  )
     ? data.products
     : [];
-  return products.sort((a, b) => b.rating - a.rating);
+
+  const addBlur = (p: Omit<PopularProduct, 'blurDataURL'>): PopularProduct => ({
+    ...p,
+    blurDataURL: generateTinyBlur(p.id),
+  });
+
+  return products
+    .map(addBlur)
+    .sort((a, b) => b.rating - a.rating);
+}
+
+function generateTinyBlur(id: number): string {
+  const shade = 220 + (id * 5) % 20; // light gray variation
+  const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='8' height='8'><rect width='8' height='8' fill='rgb(${shade},${shade},${shade})'/></svg>`;
+  return `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`;
 }


### PR DESCRIPTION
## Summary
- enhance popular products carousel arrows
- blur product images with placeholder data URLs
- generate blur placeholders when fetching products
- update product card to use blurred placeholders
- test arrow disabling when carousel doesn't overflow

## Testing
- `pnpm test --run`
- `pnpm run build` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_685c063c7df0832a8886c4aad8479c82