### PR TITLE
Add Crystallize catalogue fetcher

### DIFF
--- a/__tests__/pim-client.test.ts
+++ b/__tests__/pim-client.test.ts
@@ -1,0 +1,21 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockResponse = { catalogue: { id: 'p1', name: 'Demo', path: '/demo', defaultVariant: { price: 10, priceVariants: [{ price: 10 }], firstImage: { url: 'img.jpg' } } } };
+
+describe('Crystallize catalogue fetcher', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...OLD_ENV, CRYSTALLIZE_TENANT_IDENTIFIER: 'demo', CRYSTALLIZE_ACCESS_TOKEN_ID: 'id', CRYSTALLIZE_ACCESS_TOKEN_SECRET: 'secret' };
+    global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve(mockResponse) })) as any;
+  });
+
+  it('includes tenant slug in request url', async () => {
+    const { getProduct } = await import('../lib/pim/catalogue');
+    await getProduct('demo');
+    expect(fetch).toHaveBeenCalled();
+    const url = (fetch as any).mock.calls[0][0];
+    expect(url).toContain('/demo/catalogue');
+  });
+});

--- a/lib/pim/catalogue.ts
+++ b/lib/pim/catalogue.ts
@@ -1,0 +1,82 @@
+import { crystallize } from './crystallizeClient';
+
+type ProductDTO = {
+  id: string;
+  name: string;
+  slug: string;
+  price: number;
+  imageUrl: string;
+};
+
+export async function getProduct(slug: string): Promise<ProductDTO | null> {
+  const query = `query GetProduct($path: String!) {
+    catalogue(path: $path, language: "en") {
+      ... on Product {
+        id
+        name
+        path
+        defaultVariant {
+          price
+          priceVariants {
+            identifier
+            price
+            currency
+          }
+          firstImage {
+            url
+          }
+        }
+      }
+    }
+  }`;
+  const variables = { path: `/${slug}` };
+  const data = await crystallize.catalogueApi(query, variables);
+  const item = data.catalogue;
+  if (!item) return null;
+  const variant = item.defaultVariant || {};
+  const priceVariant = Array.isArray(variant.priceVariants) ? variant.priceVariants[0] : undefined;
+  return {
+    id: item.id,
+    name: item.name,
+    slug: item.path.replace(/^\//, ''),
+    price: priceVariant?.price ?? variant.price ?? 0,
+    imageUrl: variant.firstImage?.url ?? '',
+  };
+}
+
+export async function getProductsByCategory(slug: string, first = 24, after: string | null = null): Promise<ProductDTO[]> {
+  const query = `query GetProductsByCategory($topic: String!, $first: Int!, $after: String) {
+    search(language: "en", filter: { topics: { include: [$topic] } }, first: $first, after: $after) {
+      edges {
+        node {
+          ... on Product {
+            id
+            name
+            path
+            defaultVariant {
+              price
+              firstImage {
+                url
+              }
+            }
+          }
+        }
+      }
+    }
+  }`;
+  const variables: any = { topic: `/categories/${slug}`, first };
+  if (after) variables.after = after;
+  const data = await crystallize.catalogueApi(query, variables);
+  const edges = data.search?.edges || [];
+  return edges.map((e: any) => {
+    const p = e.node;
+    const variant = p.defaultVariant || {};
+    return {
+      id: p.id,
+      name: p.name,
+      slug: p.path.replace(/^\//, ''),
+      price: variant.price ?? 0,
+      imageUrl: variant.firstImage?.url ?? '',
+    };
+  });
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@crystallize/js-api-client": "^4.3.0",
     "@headlessui/react": "*",
     "@heroicons/react": "*",
     "@next-auth/prisma-adapter": "1.0.7",
@@ -26,6 +27,7 @@
     "zustand": "^4.0.0"
   },
   "devDependencies": {
+    "@crystallize/cli": "^3.14.1",
     "@tailwindcss/forms": "*",
     "@tailwindcss/typography": "*",
     "@testing-library/dom": "^10.4.0",
@@ -43,7 +45,6 @@
     "next-router-mock": "^1.0.2",
     "postcss": "^8",
     "tailwindcss": "3.4.4",
-    "@crystallize/cli": "^3.14.1",
     "ts-node": "^10.9.2",
     "typescript": "^5",
     "vitest": "^3.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@crystallize/js-api-client':
+        specifier: ^4.3.0
+        version: 4.3.0
       '@headlessui/react':
         specifier: '*'
         version: 2.2.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -345,6 +348,9 @@ packages:
 
   '@crystallize/import-utilities@0.94.2':
     resolution: {integrity: sha512-Q9Jz4S/+0XjjL1mRfiRG4uO899y2mCpoPxAVxKyOGdMUzteyO84Sg+sel2voQKx5qfWaPSkBp9qLQD25xQZfjA==}
+
+  '@crystallize/js-api-client@4.3.0':
+    resolution: {integrity: sha512-9zy8cR+2ZgGOJQ5oYjGXCxuCboaeBfNiNxAXEiJ9vuRmY6g6weMG16rP9X2sD+4xaAYqwV8AmGTollVyZzi5OA==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -2354,6 +2360,10 @@ packages:
     resolution: {integrity: sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==}
     engines: {node: '>=10'}
 
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
   download@8.0.0:
     resolution: {integrity: sha512-ASRY5QhDk7FK+XrQtQyvhpDKanLluEEQtWl/J7Lxuf/b+i8RYh997QeXvL85xitrmRKVlx9c7eTrcRdq2GS4eA==}
     engines: {node: '>=10'}
@@ -3483,6 +3493,9 @@ packages:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
 
+  mime-lite@1.0.3:
+    resolution: {integrity: sha512-V85l97zJSTG8FEvmdTlmNYb0UMrVBwvRjw7bWTf/aT6KjFwtz3iTz8D2tuFIp7lwiaO2C5ecnrEmSkkMRCrqVw==}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
@@ -4466,6 +4479,9 @@ packages:
     resolution: {integrity: sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==}
     engines: {node: '>=0.10.0'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -5297,8 +5313,8 @@ snapshots:
       immer: 9.0.21
       import-jsx: 4.0.1
       ink: 3.2.0(@types/react@19.1.8)(react@17.0.2)
-      ink-link: 2.0.1(ink@3.2.0(@types/react@19.1.8)(react@17.0.2))(react@17.0.2)
-      ink-text-input: 4.0.3(ink@3.2.0(@types/react@19.1.8)(react@17.0.2))(react@17.0.2)
+      ink-link: 2.0.1(ink@3.2.0(@types/react@19.1.8)(react@19.1.0))(react@17.0.2)
+      ink-text-input: 4.0.3(ink@3.2.0(@types/react@19.1.8)(react@19.1.0))(react@17.0.2)
       meow: 7.1.1
       node-fetch: 2.7.0
       react: 17.0.2
@@ -5338,6 +5354,14 @@ snapshots:
       xml-js: 1.6.11
     transitivePeerDependencies:
       - encoding
+
+  '@crystallize/js-api-client@4.3.0':
+    dependencies:
+      dotenv: 16.6.1
+      json-to-graphql-query: 2.3.0
+      mime-lite: 1.0.3
+      tiny-invariant: 1.3.3
+      zod: 3.25.67
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -7358,6 +7382,8 @@ snapshots:
 
   dotenv@10.0.0: {}
 
+  dotenv@16.6.1: {}
+
   download@8.0.0:
     dependencies:
       archive-type: 4.0.0
@@ -8224,14 +8250,14 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ink-link@2.0.1(ink@3.2.0(@types/react@19.1.8)(react@17.0.2))(react@17.0.2):
+  ink-link@2.0.1(ink@3.2.0(@types/react@19.1.8)(react@19.1.0))(react@17.0.2):
     dependencies:
       ink: 3.2.0(@types/react@19.1.8)(react@17.0.2)
       prop-types: 15.8.1
       react: 17.0.2
       terminal-link: 2.1.1
 
-  ink-text-input@4.0.3(ink@3.2.0(@types/react@19.1.8)(react@17.0.2))(react@17.0.2):
+  ink-text-input@4.0.3(ink@3.2.0(@types/react@19.1.8)(react@19.1.0))(react@17.0.2):
     dependencies:
       chalk: 4.1.2
       ink: 3.2.0(@types/react@19.1.8)(react@17.0.2)
@@ -8730,6 +8756,8 @@ snapshots:
   mime-db@1.52.0: {}
 
   mime-db@1.54.0: {}
+
+  mime-lite@1.0.3: {}
 
   mime-types@2.1.35:
     dependencies:
@@ -9810,6 +9838,8 @@ snapshots:
   through@2.3.8: {}
 
   timed-out@4.0.1: {}
+
+  tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
## Summary
- add Crystallize catalogue client functions
- install `@crystallize/js-api-client`
- test new catalogue fetcher

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6862538104f4832a8894f5c645c52c5a