### PR TITLE
Fix workflow error handling for Crystallize import

### DIFF
--- a/.github/workflows/crystallize-import.yml
+++ b/.github/workflows/crystallize-import.yml
@@ -58,7 +58,7 @@ jobs:
             --batch-size 50 --max-tries 5 --update \
             --path crystallize-import \
             > import.log 2>&1
-          tail -n 1 import.log > import.json
+          grep -o '{.*}' import.log | tail -n 1 > import.json
         env:
           CRYSTALLIZE_TENANT_IDENTIFIER: ${{ secrets.CRYSTALLIZE_TENANT_IDENTIFIER }}
           CRYSTALLIZE_TENANT_ID:         ${{ secrets.CRYSTALLIZE_TENANT_ID }}
@@ -80,6 +80,9 @@ jobs:
             echo "::error::import.json is empty" && cat import.log && exit 1
           fi
           ITEMS=$(jq '.itemsCreated // 0' import.json 2>/dev/null || echo 0)
+          case "$ITEMS" in
+            ''|*[!0-9]*) ITEMS=0 ;;
+          esac
           if [ "$ITEMS" -eq 0 ]; then
             echo "::error::Import created 0 items" && exit 1
           fi

--- a/.github/workflows/crystallize-import.yml
+++ b/.github/workflows/crystallize-import.yml
@@ -57,7 +57,8 @@ jobs:
             --tenant               "$TENANT" \
             --batch-size 50 --max-tries 5 --update \
             --path crystallize-import \
-            | tail -n 1 > import.json
+            > import.log 2>&1
+          tail -n 1 import.log > import.json
         env:
           CRYSTALLIZE_TENANT_IDENTIFIER: ${{ secrets.CRYSTALLIZE_TENANT_IDENTIFIER }}
           CRYSTALLIZE_TENANT_ID:         ${{ secrets.CRYSTALLIZE_TENANT_ID }}
@@ -65,12 +66,19 @@ jobs:
           CRYSTALLIZE_ACCESS_TOKEN_SECRET: ${{ secrets.CRYSTALLIZE_ACCESS_TOKEN_SECRET }}
           CI: true
 
-      - name: Debug import.json
-        run: cat import.json
+      - name: Debug import logs
+        run: |
+          echo "--- import.log ---"
+          cat import.log || true
+          echo "--- import.json ---"
+          cat import.json || true
 
 
       - name: Fail when nothing was created
         run: |
+          if [ ! -s import.json ]; then
+            echo "::error::import.json is empty" && cat import.log && exit 1
+          fi
           ITEMS=$(jq '.itemsCreated // 0' import.json 2>/dev/null || echo 0)
           if [ "$ITEMS" -eq 0 ]; then
             echo "::error::Import created 0 items" && exit 1

--- a/.github/workflows/crystallize-import.yml
+++ b/.github/workflows/crystallize-import.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Fail when nothing was created
         run: |
-          ITEMS=$(jq '.itemsCreated' import.json)
+          ITEMS=$(jq '.itemsCreated // 0' import.json 2>/dev/null || echo 0)
           if [ "$ITEMS" -eq 0 ]; then
             echo "::error::Import created 0 items" && exit 1
           fi

--- a/.github/workflows/crystallize-import.yml
+++ b/.github/workflows/crystallize-import.yml
@@ -57,13 +57,16 @@ jobs:
             --tenant               "$TENANT" \
             --batch-size 50 --max-tries 5 --update \
             --path crystallize-import \
-            > import.json
+            | tail -n 1 > import.json
         env:
           CRYSTALLIZE_TENANT_IDENTIFIER: ${{ secrets.CRYSTALLIZE_TENANT_IDENTIFIER }}
           CRYSTALLIZE_TENANT_ID:         ${{ secrets.CRYSTALLIZE_TENANT_ID }}
           CRYSTALLIZE_ACCESS_TOKEN_ID:   ${{ secrets.CRYSTALLIZE_ACCESS_TOKEN_ID }}
           CRYSTALLIZE_ACCESS_TOKEN_SECRET: ${{ secrets.CRYSTALLIZE_ACCESS_TOKEN_SECRET }}
           CI: true
+
+      - name: Debug import.json
+        run: cat import.json
 
 
       - name: Fail when nothing was created


### PR DESCRIPTION
## Summary
- avoid jq parse errors in the Crystallize import workflow

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6862ae466a90832aab5023863ae9b7ed