### PR TITLE
feat: cache product and search API responses

### DIFF
--- a/bff/utils/fetchData.js
+++ b/bff/utils/fetchData.js
@@ -5,7 +5,7 @@
  * @throws {Error} If the network response is not ok.
  */
 export async function fetchData(url) {
-  const response = await fetch(url);
+  const response = await fetch(url, { next: { revalidate: 60 } });
   if (!response.ok) {
     throw new Error(`HTTP error! status: ${response.status} while fetching ${url}`);
   }

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -1,0 +1,44 @@
+import { getProducts, DEFAULT_LIMIT } from '@/bff/services';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const category = searchParams.get('category') ?? undefined;
+  const sort = (searchParams.get('sort') as 'relevance' | 'price_asc' | 'price_desc' | 'newest') ?? 'relevance';
+  const skipParam = Number(searchParams.get('skip') ?? '0');
+  const limitParam = Number(searchParams.get('limit') ?? String(DEFAULT_LIMIT));
+  const brandsParam = searchParams.get('brands');
+  const minPriceParam = searchParams.get('minPrice');
+  const maxPriceParam = searchParams.get('maxPrice');
+
+  const skip = Number.isNaN(skipParam) ? 0 : skipParam;
+  const limit = Number.isNaN(limitParam) ? DEFAULT_LIMIT : limitParam;
+  const brands = brandsParam
+    ? brandsParam.split(',').map((b) => b.trim()).filter(Boolean)
+    : undefined;
+  const minPrice = minPriceParam ? Number(minPriceParam) : undefined;
+  const maxPrice = maxPriceParam ? Number(maxPriceParam) : undefined;
+
+  try {
+    const results = await getProducts({
+      category,
+      sort,
+      skip,
+      limit,
+      brands,
+      minPrice,
+      maxPrice,
+    });
+    return NextResponse.json(results, {
+      headers: {
+        'Cache-Control': 'public, max-age=60, s-maxage=60, stale-while-revalidate=60',
+      },
+    });
+  } catch (error) {
+    console.error('Products API error:', error);
+    return NextResponse.json(
+      { message: 'Error fetching products', items: [] },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -21,7 +21,11 @@ export async function GET(request: NextRequest) {
   try {
     // The searchProducts service already handles B2B pricing and Zod validation
     const results = await searchProducts(term, sort, skip, limit);
-    return NextResponse.json(results);
+    return NextResponse.json(results, {
+      headers: {
+        'Cache-Control': 'public, max-age=60, s-maxage=60, stale-while-revalidate=60',
+      },
+    });
   } catch (error) {
     console.error('Search API error:', error);
     return NextResponse.json(

--- a/src/lib/services/dummyjson.ts
+++ b/src/lib/services/dummyjson.ts
@@ -102,7 +102,7 @@ export async function fetchProducts(options: GetProductsOptions = {}) {
 
   let data: DummyJsonResponse;
   try {
-    const response = await fetch(url);
+    const response = await fetch(url, { next: { revalidate: 60 } });
     if (!response.ok) {
       return { products: [], total: 0, skip: 0, limit: 0 } as DummyJsonResponse;
     }
@@ -198,7 +198,7 @@ export async function fetchProducts(options: GetProductsOptions = {}) {
 export async function fetchProductById(id: number | string) {
   let product: DummyJsonProductRaw | undefined;
   try {
-    const response = await fetch(`${API_BASE_URL}/products/${id}`);
+    const response = await fetch(`${API_BASE_URL}/products/${id}`, { next: { revalidate: 60 } });
     if (!response.ok) {
       return undefined;
     }
@@ -221,7 +221,7 @@ export async function searchProducts(query: string, sort?: string, skip = 0, lim
   if (sort && sort !== 'relevance') params.append('sort', sort);
   let data: DummyJsonResponse;
   try {
-    const response = await fetch(`${API_BASE_URL}/products/search?${params.toString()}`);
+    const response = await fetch(`${API_BASE_URL}/products/search?${params.toString()}`, { next: { revalidate: 60 } });
     if (!response.ok) {
       return { products: [], total: 0, skip: 0, limit: 0 } as DummyJsonResponse;
     }
@@ -308,7 +308,7 @@ export async function fetchCategories(fetchOptions?: RequestInit) {
 export async function fetchAllProductsSimple() {
   let data: DummyJsonResponse;
   try {
-    const response = await fetch(`${API_BASE_URL}/products?limit=0`);
+    const response = await fetch(`${API_BASE_URL}/products?limit=0`, { next: { revalidate: 60 } });
     if (!response.ok) {
       return { products: [], total: 0, skip: 0, limit: 0 } as DummyJsonResponse;
     }


### PR DESCRIPTION
## Summary
- add `/api/products` route with cache headers
- enable caching for search API and underlying fetch calls

## Testing
- `pnpm test`
- `curl -I http://localhost:3000/api/products`
- `curl -I http://localhost:3000/api/search?term=phone`


------
https://chatgpt.com/codex/tasks/task_e_6890bf8bda08832a9c43809302d901a5