### PR TITLE
feat: add quick order page

### DIFF
--- a/src/app/(protected)/quick-order/QuickOrderForm.test.tsx
+++ b/src/app/(protected)/quick-order/QuickOrderForm.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import QuickOrderForm from './QuickOrderForm';
+import '@testing-library/jest-dom';
+import { vi, Mock } from 'vitest';
+import { useCartStore } from '@/stores/useCartStore';
+
+vi.mock('@/bff/services', () => ({
+  getProductByIdOrSlug: vi.fn(),
+}));
+
+import { getProductByIdOrSlug } from '@/bff/services';
+const mockedGetProduct = getProductByIdOrSlug as Mock;
+
+describe('QuickOrderForm', () => {
+  beforeEach(() => {
+    mockedGetProduct.mockReset();
+    useCartStore.setState(useCartStore.getInitialState(), true);
+  });
+
+  test('renders at least three SKU rows', () => {
+    render(<QuickOrderForm />);
+    const skuInputs = screen.getAllByLabelText(/sku/i);
+    expect(skuInputs.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test('adds multiple valid SKUs to cart and updates totals', async () => {
+    mockedGetProduct.mockImplementation(async (idOrSlug: string) => ({
+      id: Number(idOrSlug),
+      title: `Product ${idOrSlug}`,
+      slug: `p-${idOrSlug}`,
+      description: 'desc',
+      price: 5,
+      category: { id: 1, name: 'cat', slug: 'cat' },
+    }));
+
+    render(<QuickOrderForm />);
+    const skuInputs = screen.getAllByLabelText(/sku/i);
+    const qtyInputs = screen.getAllByLabelText(/quantity/i);
+
+    fireEvent.change(skuInputs[0], { target: { value: '1' } });
+    fireEvent.change(qtyInputs[0], { target: { value: '1' } });
+    fireEvent.change(skuInputs[1], { target: { value: '2' } });
+    fireEvent.change(qtyInputs[1], { target: { value: '2' } });
+    fireEvent.change(skuInputs[2], { target: { value: '3' } });
+    fireEvent.change(qtyInputs[2], { target: { value: '3' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /add to cart/i }));
+
+    await waitFor(() => {
+      expect(useCartStore.getState().getTotalItems()).toBe(6);
+    });
+    expect(useCartStore.getState().getCartSubtotal()).toBe(30);
+  });
+
+  test('shows error for invalid SKU', async () => {
+    mockedGetProduct.mockRejectedValueOnce(new Error('not found'));
+    render(<QuickOrderForm />);
+    const skuInputs = screen.getAllByLabelText(/sku/i);
+    const qtyInputs = screen.getAllByLabelText(/quantity/i);
+
+    fireEvent.change(skuInputs[0], { target: { value: 'bad' } });
+    fireEvent.change(qtyInputs[0], { target: { value: '1' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /add to cart/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid SKU')).toBeInTheDocument();
+    });
+    expect(useCartStore.getState().getTotalItems()).toBe(0);
+  });
+});

--- a/src/app/(protected)/quick-order/QuickOrderForm.tsx
+++ b/src/app/(protected)/quick-order/QuickOrderForm.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+import { getProductByIdOrSlug } from '@/bff/services';
+import { useCartStore } from '@/stores/useCartStore';
+
+interface Row {
+  sku: string;
+  quantity: number;
+  error?: string;
+}
+
+export default function QuickOrderForm() {
+  const addItem = useCartStore((state) => state.addItem);
+  const [rows, setRows] = useState<Row[]>([
+    { sku: '', quantity: 1 },
+    { sku: '', quantity: 1 },
+    { sku: '', quantity: 1 },
+  ]);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleAddRow = () => {
+    setRows((prev) => [...prev, { sku: '', quantity: 1 }]);
+  };
+
+  const handleChange = (
+    index: number,
+    field: 'sku' | 'quantity',
+    value: string
+  ) => {
+    setRows((prev) => {
+      const updated = [...prev];
+      updated[index] = {
+        ...updated[index],
+        [field]: field === 'quantity' ? Number(value) : value,
+        error: undefined,
+      };
+      return updated;
+    });
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    const updatedRows = rows.map((r) => ({ ...r, error: undefined }));
+
+    for (let i = 0; i < rows.length; i++) {
+      const { sku, quantity } = rows[i];
+      if (!sku) {
+        updatedRows[i].error = 'SKU required';
+        continue;
+      }
+      if (quantity <= 0) {
+        updatedRows[i].error = 'Quantity must be > 0';
+        continue;
+      }
+      try {
+        const product = await getProductByIdOrSlug(sku);
+        addItem(product, quantity);
+      } catch {
+        updatedRows[i].error = 'Invalid SKU';
+      }
+    }
+
+    setRows(updatedRows);
+    setSubmitting(false);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <table className="min-w-full divide-y divide-gray-200">
+        <thead>
+          <tr>
+            <th className="py-2 text-left">SKU</th>
+            <th className="py-2 text-left">Quantity</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, index) => (
+            <tr key={index} className="border-b">
+              <td className="py-2">
+                <input
+                  aria-label="SKU"
+                  placeholder="SKU"
+                  type="text"
+                  value={row.sku}
+                  onChange={(e) => handleChange(index, 'sku', e.target.value)}
+                  className="border p-2 w-full"
+                />
+                {row.error && (
+                  <p className="text-red-500 text-sm">{row.error}</p>
+                )}
+              </td>
+              <td className="py-2">
+                <input
+                  aria-label="Quantity"
+                  type="number"
+                  min={1}
+                  value={row.quantity}
+                  onChange={(e) => handleChange(index, 'quantity', e.target.value)}
+                  className="border p-2 w-24"
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={handleAddRow}
+          className="px-3 py-2 bg-gray-200 rounded"
+        >
+          Add Row
+        </button>
+        <button
+          type="submit"
+          disabled={submitting}
+          className="px-3 py-2 bg-blue-600 text-white rounded"
+        >
+          {submitting ? 'Adding...' : 'Add to Cart'}
+        </button>
+      </div>
+    </form>
+  );
+}
+

--- a/src/app/(protected)/quick-order/page.tsx
+++ b/src/app/(protected)/quick-order/page.tsx
@@ -1,0 +1,14 @@
+// src/app/(protected)/quick-order/page.tsx
+import AuthGuard from '@/components/AuthGuard';
+import QuickOrderForm from './QuickOrderForm';
+
+export default function QuickOrderPage() {
+  return (
+    <AuthGuard>
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold mb-6">Quick Order</h1>
+        <QuickOrderForm />
+      </div>
+    </AuthGuard>
+  );
+}


### PR DESCRIPTION
## Summary
- add Quick Order page and client form for bulk SKU entry
- validate SKUs, add items to cart, and handle inline errors
- test QuickOrderForm behavior for valid and invalid SKUs

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_6890dab3482c832a9d2423072978a137