### PR TITLE
feat: add quotes tab under account

### DIFF
--- a/data/quotes.json
+++ b/data/quotes.json
@@ -1,0 +1,1 @@
+{"id":"q1","userId":"1","status":"submitted","createdAt":"2024-01-01T00:00:00.000Z","cart":{"items":[{"productId":1,"quantity":2}]},"user":{"name":"John Doe","email":"john@example.com"}}

--- a/src/app/(protected)/account/quotes/[id]/page.tsx
+++ b/src/app/(protected)/account/quotes/[id]/page.tsx
@@ -1,0 +1,65 @@
+import AuthGuard from '@/components/AuthGuard';
+import AccountTabs from '@/components/AccountTabs';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { headers } from 'next/headers';
+import Link from 'next/link';
+import type { CartItem, Quote } from '@/types';
+
+async function getQuote(id: string): Promise<Quote | null> {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return null;
+  }
+  const host = headers().get('host');
+  const protocol = process.env.NODE_ENV === 'production' ? 'https' : 'http';
+  const res = await fetch(`${protocol}://${host}/api/quotes/${id}?userId=${session.user.id}`, {
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    return null;
+  }
+  return (await res.json()) as Quote;
+}
+
+export default async function QuoteDetailPage({ params }: { params: { id: string } }) {
+  const quote = await getQuote(params.id);
+
+  if (!quote) {
+    return (
+      <AuthGuard>
+        <div className="container mx-auto px-4 py-8">
+          <h1 className="text-3xl font-bold mb-6">My Account</h1>
+          <AccountTabs active="quotes" />
+          <h2 className="text-2xl font-semibold mb-4">Quote Not Found</h2>
+          <Link href="/account/quotes" className="text-blue-600 hover:underline">
+            Back to Quotes
+          </Link>
+        </div>
+      </AuthGuard>
+    );
+  }
+
+  return (
+    <AuthGuard>
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold mb-6">My Account</h1>
+        <AccountTabs active="quotes" />
+        <h2 className="text-2xl font-semibold mb-4">Quote {quote.id}</h2>
+        <p className="mb-4">Status: {quote.status}</p>
+        {quote.cart?.items?.length > 0 && (
+          <ul className="mb-6 list-disc list-inside">
+            {quote.cart.items.map((item: CartItem, idx: number) => (
+              <li key={idx}>
+                Product {item.productId} × {item.quantity}
+              </li>
+            ))}
+          </ul>
+        )}
+        <Link href="/account/quotes" className="text-blue-600 hover:underline">
+          Back to Quotes
+        </Link>
+      </div>
+    </AuthGuard>
+  );
+}

--- a/src/app/(protected)/account/quotes/page.tsx
+++ b/src/app/(protected)/account/quotes/page.tsx
@@ -1,0 +1,41 @@
+import AuthGuard from '@/components/AuthGuard';
+import OrderTable from '@/components/OrderTable';
+import AccountTabs from '@/components/AccountTabs';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { headers } from 'next/headers';
+import type { Quote } from '@/types';
+
+async function getQuotes(): Promise<Quote[]> {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return [] as Quote[];
+  }
+  const host = headers().get('host');
+  const protocol = process.env.NODE_ENV === 'production' ? 'https' : 'http';
+  const res = await fetch(`${protocol}://${host}/api/quotes?userId=${session.user.id}`, {
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    return [] as Quote[];
+  }
+  return res.json();
+}
+
+export default async function QuotesPage() {
+  const quotes = await getQuotes();
+  return (
+    <AuthGuard>
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold mb-6">My Account</h1>
+        <AccountTabs active="quotes" />
+        <OrderTable
+          items={quotes}
+          basePath="/account/quotes"
+          idLabel="Quote ID"
+          emptyMessage="You have no quotes."
+        />
+      </div>
+    </AuthGuard>
+  );
+}

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -1,5 +1,6 @@
 // src/app/account/page.tsx
 import AuthGuard from '@/components/AuthGuard';
+import AccountTabs from '@/components/AccountTabs';
 import React from 'react';
 import Link from 'next/link';
 import { Order } from '@/types/order';
@@ -31,6 +32,7 @@ export default async function AccountPage() {
     <AuthGuard>
       <div className="container mx-auto px-4 py-8">
         <h1 className="text-3xl font-bold mb-6">My Account</h1>
+        <AccountTabs active="orders" />
         {accountData && (
           <div className="bg-white p-6 rounded-lg shadow mb-6">
             <h2 className="text-xl font-semibold mb-2">Profile</h2>

--- a/src/app/api/quote/route.ts
+++ b/src/app/api/quote/route.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { nanoid } from 'nanoid';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 
 export const dynamic = 'force-dynamic';
 
@@ -39,11 +41,14 @@ export async function POST(request: Request) {
   }
 
   const quoteId = nanoid();
+  const session = await getServerSession(authOptions);
   const record = {
     id: quoteId,
+    userId: session?.user?.id ?? null,
+    status: 'submitted',
     ...parsed.data,
     createdAt: new Date().toISOString(),
-  };
+  } as const;
   const baseDir = process.env.VERCEL
     ? '/tmp'
     : path.join(process.cwd(), 'data');

--- a/src/app/api/quotes/[id]/route.ts
+++ b/src/app/api/quotes/[id]/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import type { Quote } from '@/types';
+
+export const dynamic = 'force-dynamic';
+
+async function readQuotes(): Promise<Quote[]> {
+  const baseDir = process.env.VERCEL ? '/tmp' : path.join(process.cwd(), 'data');
+  const filePath = path.join(baseDir, 'quotes.json');
+  try {
+    const data = await fs.readFile(filePath, 'utf8');
+    return data
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as Quote);
+  } catch (err: unknown) {
+    const error = err as NodeJS.ErrnoException;
+    if (error.code === 'ENOENT') {
+      return [];
+    }
+    throw err;
+  }
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const { searchParams } = new URL(request.url);
+  const userId = searchParams.get('userId');
+
+  try {
+    const quotes = await readQuotes();
+    const quote = quotes.find(
+      (q) => q.id === params.id && (!userId || String(q.userId) === String(userId))
+    );
+    if (!quote) {
+      return NextResponse.json({ message: 'Quote not found' }, { status: 404 });
+    }
+    return NextResponse.json(quote);
+  } catch (err) {
+    console.error('Failed to read quotes', err);
+    return NextResponse.json(
+      { message: 'Failed to load quote' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/quotes/route.ts
+++ b/src/app/api/quotes/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import type { Quote } from '@/types';
+
+export const dynamic = 'force-dynamic';
+
+async function readQuotes(): Promise<Quote[]> {
+  const baseDir = process.env.VERCEL ? '/tmp' : path.join(process.cwd(), 'data');
+  const filePath = path.join(baseDir, 'quotes.json');
+  try {
+    const data = await fs.readFile(filePath, 'utf8');
+    return data
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as Quote);
+  } catch (err: unknown) {
+    const error = err as NodeJS.ErrnoException;
+    if (error.code === 'ENOENT') {
+      return [];
+    }
+    throw err;
+  }
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const userId = searchParams.get('userId');
+
+  try {
+    const quotes = await readQuotes();
+    const filtered = userId
+      ? quotes.filter((q) => String(q.userId) === String(userId))
+      : quotes;
+    return NextResponse.json(filtered);
+  } catch (err) {
+    console.error('Failed to read quotes', err);
+    return NextResponse.json(
+      { message: 'Failed to load quotes' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/AccountTabs.tsx
+++ b/src/components/AccountTabs.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+
+interface AccountTabsProps {
+  active: 'orders' | 'quotes';
+}
+
+export default function AccountTabs({ active }: AccountTabsProps) {
+  const tabClass = (tab: 'orders' | 'quotes') =>
+    `px-4 py-2 border-b-2 ${active === tab ? 'border-blue-600 text-blue-600' : 'border-transparent text-gray-600 hover:text-gray-800'}`;
+
+  return (
+    <nav className="mb-6 flex space-x-4">
+      <Link href="/account" className={tabClass('orders')}>
+        Orders
+      </Link>
+      <Link href="/account/quotes" className={tabClass('quotes')}>
+        Quotes
+      </Link>
+    </nav>
+  );
+}

--- a/src/components/OrderTable.tsx
+++ b/src/components/OrderTable.tsx
@@ -1,0 +1,55 @@
+import Link from 'next/link';
+
+export interface OrderLike {
+  id: string | number;
+  createdAt?: string;
+  status?: string;
+}
+
+interface OrderTableProps {
+  items: OrderLike[];
+  basePath: string;
+  emptyMessage?: string;
+  idLabel?: string;
+}
+
+export default function OrderTable({
+  items,
+  basePath,
+  emptyMessage = 'No records found.',
+  idLabel = 'ID',
+}: OrderTableProps) {
+  if (!items || items.length === 0) {
+    return <p className="text-gray-700">{emptyMessage}</p>;
+  }
+
+  return (
+    <table className="min-w-full divide-y divide-gray-200">
+      <thead className="bg-gray-50">
+        <tr>
+          <th className="px-4 py-2 text-left text-sm font-semibold text-gray-700">{idLabel}</th>
+          <th className="px-4 py-2 text-left text-sm font-semibold text-gray-700">Status</th>
+          <th className="px-4 py-2 text-left text-sm font-semibold text-gray-700">Created</th>
+        </tr>
+      </thead>
+      <tbody className="divide-y divide-gray-200">
+        {items.map((item) => (
+          <tr key={item.id}>
+            <td className="px-4 py-2">
+              <Link
+                href={`${basePath}/${item.id}`}
+                className="text-blue-600 hover:underline"
+              >
+                {item.id}
+              </Link>
+            </td>
+            <td className="px-4 py-2">{item.status ?? 'N/A'}</td>
+            <td className="px-4 py-2">
+              {item.createdAt ? new Date(item.createdAt).toLocaleDateString() : 'N/A'}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -25,3 +25,4 @@ export type Product = {
 };
 
 export type { CartItem, CheckoutSession } from './order';
+export type { Quote } from './quote';

--- a/types/quote.ts
+++ b/types/quote.ts
@@ -1,0 +1,17 @@
+import type { CartItem } from './order';
+
+export interface Quote {
+  id: string;
+  userId: string | number | null;
+  status: string;
+  createdAt: string;
+  cart?: {
+    items: CartItem[];
+  };
+  user?: {
+    name?: string;
+    email?: string;
+    phone?: string;
+  };
+}
+


### PR DESCRIPTION
## Summary
- list user quotes on a new My Account tab
- expose `/api/quotes` for retrieving stored quotes
- record userId and status when submitting quote requests
- tighten TypeScript typings for quotes pages and APIs
- render AccountTabs navigation so Quotes tab is visible and reachable
- derive API base URL from request headers to avoid fetch errors in account/quotes pages

## Testing
- `pnpm lint`
- `pnpm vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6890da45f70c832a8d1d864253846e10