### PR TITLE
Sync orders and quotes into account history

### DIFF
--- a/__tests__/history.test.ts
+++ b/__tests__/history.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { POST as postQuote } from '../src/app/api/quote/route';
+import { GET as getQuotes } from '../src/app/api/quotes/route';
+import { POST as postOrder } from '../src/app/api/order/route';
+import { GET as getOrders } from '../src/app/api/orders/route';
+import { promises as fs } from 'node:fs';
+
+vi.mock('../src/app/api/auth/[...nextauth]/route', () => ({ authOptions: {} }));
+vi.mock('next-auth/next', () => ({
+  getServerSession: vi.fn(async () => ({ user: { id: '1' } })),
+}));
+
+beforeEach(async () => {
+  process.env.VERCEL = '1';
+  try {
+    await fs.unlink('/tmp/user-history.json');
+  } catch {}
+});
+
+describe('user history', () => {
+  it('stores quotes and orders', async () => {
+    const quoteReq = new Request('http://localhost/api/quote', {
+      method: 'POST',
+      body: JSON.stringify({
+        cart: { items: [{ productId: 1, quantity: 2 }] },
+        user: { name: 'Test', email: 'test@example.com' },
+      }),
+    });
+    const quoteRes = await postQuote(quoteReq);
+    expect(quoteRes.status).toBe(200);
+
+    const quotesRes = await getQuotes(
+      new Request('http://localhost/api/quotes?userId=1')
+    );
+    const quotes = await quotesRes.json();
+    expect(quotes.length).toBe(1);
+    expect(quotes[0].type).toBe('quote');
+
+    const orderReq = new Request('http://localhost/api/order', {
+      method: 'POST',
+      body: JSON.stringify({ session: { id: 'sess_1' } }),
+    });
+    const orderRes = await postOrder(orderReq);
+    expect(orderRes.status).toBe(200);
+
+    const ordersRes = await getOrders(
+      new Request('http://localhost/api/orders?userId=1')
+    );
+    const orders = await ordersRes.json();
+    expect(orders.length).toBe(1);
+    expect(orders[0].type).toBe('order');
+  });
+});

--- a/src/app/account/orders/[id]/page.tsx
+++ b/src/app/account/orders/[id]/page.tsx
@@ -2,12 +2,25 @@
 import AuthGuard from '@/components/AuthGuard';
 import React from 'react';
 import Link from 'next/link';
-import { Product } from '@/types/order';
-import AddToCartButton from '@/components/AddToCartButton';
-import { fetchCartById } from '@/lib/services/dummyjson';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import type { HistoryRecord } from '@/types';
+import { readHistory } from '@/lib/history';
 
-async function getOrderDetails(id: string) {
-  return fetchCartById(id);
+async function getOrderDetails(id: string): Promise<HistoryRecord | null> {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return null;
+  }
+  const history = await readHistory();
+  return (
+    history.find(
+      (r) =>
+        r.type === 'order' &&
+        r.id === id &&
+        String(r.userId) === String(session.user.id),
+    ) ?? null
+  );
 }
 
 export default async function OrderDetailPage({ params }: { params: { id: string } }) {
@@ -31,32 +44,14 @@ export default async function OrderDetailPage({ params }: { params: { id: string
   return (
     <AuthGuard>
       <div className="container mx-auto px-4 py-8">
-        <h1 className="text-3xl font-bold mb-6">Order #{order.id}</h1>
-        <div className="bg-white p-6 rounded-lg shadow mb-6">
-          <p><strong>Total Items:</strong> {order.totalProducts}</p>
-          <p><strong>Total Amount:</strong> ${order.total}</p>
-        </div>
-        <div className="bg-white p-6 rounded-lg shadow">
-          <div className="flex justify-between items-center mb-2">
-            <h2 className="text-xl font-semibold">Products</h2>
-            <AddToCartButton products={order.products} />
-          </div>
-          <ul>
-            {order.products.map((product: Product) => (
-              <li key={product.id} className="border-b last:border-b-0 py-2">
-                <p><strong>{product.title}</strong></p>
-                <p>Price: ${product.price}</p>
-                <p>Quantity: {product.quantity}</p>
-                <p>Total: ${product.total}</p>
-              </li>
-            ))}
-          </ul>
-        </div>
-        <p className="mt-6">
-          <Link href="/account" className="text-blue-500 hover:underline">
-            Back to My Account
-          </Link>
-        </p>
+        <h1 className="text-3xl font-bold mb-6">Order {order.id}</h1>
+        <p className="mb-4">Status: {order.status}</p>
+        {order.session?.customer?.name && (
+          <p className="mb-4">Customer: {order.session.customer.name}</p>
+        )}
+        <Link href="/account" className="text-blue-500 hover:underline">
+          Back to My Account
+        </Link>
       </div>
     </AuthGuard>
   );

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -2,11 +2,10 @@
 import AuthGuard from '@/components/AuthGuard';
 import AccountTabs from '@/components/AccountTabs';
 import React from 'react';
-import Link from 'next/link';
-import { Order } from '@/types/order';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/app/api/auth/[...nextauth]/route';
-import { fetchUser, fetchUserCarts } from '@/lib/services/dummyjson';
+import { fetchUser } from '@/lib/services/dummyjson';
+import OrderHistory from '@/components/OrderHistory';
 
 async function getAccountData() {
   const session = await getServerSession(authOptions);
@@ -16,17 +15,8 @@ async function getAccountData() {
   return fetchUser(session.user.id);
 }
 
-async function getOrders() {
-  const session = await getServerSession(authOptions);
-  if (!session?.user?.id) {
-    return { carts: [] };
-  }
-  return fetchUserCarts(session.user.id);
-}
-
 export default async function AccountPage() {
   const accountData = await getAccountData();
-  const ordersData = await getOrders();
 
   return (
     <AuthGuard>
@@ -43,19 +33,7 @@ export default async function AccountPage() {
         )}
         <div className="bg-white p-6 rounded-lg shadow">
           <h2 className="text-xl font-semibold mb-2">Recent Orders</h2>
-          {ordersData?.carts?.length > 0 ? (
-            <ul>
-              {ordersData.carts.map((order: Order) => (
-                <li key={order.id} className="border-b last:border-b-0 py-2">
-                  <Link href={`/account/orders/${order.id}`} className="text-blue-500 hover:underline">
-                    Order #{order.id} - ${order.total}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <p className="text-gray-700">You have no orders.</p>
-          )}
+          <OrderHistory emptyMessage="You have no orders." />
         </div>
       </div>
     </AuthGuard>

--- a/src/app/api/order/route.ts
+++ b/src/app/api/order/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+
+export const dynamic = 'force-dynamic';
+
+const OrderSchema = z.object({
+  session: z.object({
+    id: z.string(),
+    customer: z.object({ name: z.string().nullable().optional() }).nullable().optional(),
+  }),
+});
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ message: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const parsed = OrderSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { message: 'Invalid payload', issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  const session = await getServerSession(authOptions);
+  const record = {
+    id: parsed.data.session.id,
+    userId: session?.user?.id ?? null,
+    type: 'order' as const,
+    status: 'paid',
+    createdAt: new Date().toISOString(),
+    session: parsed.data.session,
+  };
+
+  const baseDir = process.env.VERCEL
+    ? '/tmp'
+    : path.join(process.cwd(), 'data');
+  const filePath = path.join(baseDir, 'user-history.json');
+
+  try {
+    await fs.mkdir(baseDir, { recursive: true });
+    await fs.appendFile(filePath, JSON.stringify(record) + '\n');
+  } catch (err) {
+    console.error('Failed to write order', err);
+    return NextResponse.json(
+      { message: 'Failed to store order' },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ success: true, orderId: record.id });
+}

--- a/src/app/api/orders/[id]/route.ts
+++ b/src/app/api/orders/[id]/route.ts
@@ -1,17 +1,55 @@
-// src/app/api/orders/[id]/route.ts
-import { fetchCartById } from "@/lib/services/dummyjson";
-import { NextResponse } from "next/server";
+import { NextResponse } from 'next/server';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import type { HistoryRecord } from '@/types';
+
+export const dynamic = 'force-dynamic';
+
+async function readHistory(): Promise<HistoryRecord[]> {
+  const baseDir = process.env.VERCEL ? '/tmp' : path.join(process.cwd(), 'data');
+  const filePath = path.join(baseDir, 'user-history.json');
+  try {
+    const data = await fs.readFile(filePath, 'utf8');
+    return data
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as HistoryRecord);
+  } catch (err: unknown) {
+    const error = err as NodeJS.ErrnoException;
+    if (error.code === 'ENOENT') {
+      return [];
+    }
+    throw err;
+  }
+}
 
 export async function GET(
   request: Request,
   { params }: { params: { id: string } }
 ) {
-  const id = params.id;
-  const cart = await fetchCartById(id);
+  const { searchParams } = new URL(request.url);
+  const userId = searchParams.get('userId');
 
-  if (!cart) {
-    return NextResponse.json({ message: "Cart not found" }, { status: 404 });
+  try {
+    const records = await readHistory();
+    const order = records.find(
+      (r) =>
+        r.type === 'order' &&
+        r.id === params.id &&
+        (!userId || String(r.userId) === String(userId))
+    );
+    if (!order) {
+      return NextResponse.json(
+        { message: 'Order not found' },
+        { status: 404 }
+      );
+    }
+    return NextResponse.json(order);
+  } catch (err) {
+    console.error('Failed to read order', err);
+    return NextResponse.json(
+      { message: 'Failed to load order' },
+      { status: 500 }
+    );
   }
-
-  return NextResponse.json(cart);
 }

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -1,17 +1,45 @@
-// src/app/api/orders/route.ts
-import { getServerSession } from "next-auth/next";
-import { authOptions } from "@/app/api/auth/[...nextauth]/route";
-import { fetchUserCarts } from "@/lib/services/dummyjson";
-import { NextResponse } from "next/server";
+import { NextResponse } from 'next/server';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import type { HistoryRecord } from '@/types';
 
-export async function GET() {
-  const session = await getServerSession(authOptions);
+export const dynamic = 'force-dynamic';
 
-  if (!session?.user?.id) {
-    return NextResponse.json({ message: "Not authenticated" }, { status: 401 });
+async function readHistory(): Promise<HistoryRecord[]> {
+  const baseDir = process.env.VERCEL ? '/tmp' : path.join(process.cwd(), 'data');
+  const filePath = path.join(baseDir, 'user-history.json');
+  try {
+    const data = await fs.readFile(filePath, 'utf8');
+    return data
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as HistoryRecord);
+  } catch (err: unknown) {
+    const error = err as NodeJS.ErrnoException;
+    if (error.code === 'ENOENT') {
+      return [];
+    }
+    throw err;
   }
+}
 
-  const carts = await fetchUserCarts(session.user.id);
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const userId = searchParams.get('userId');
 
-  return NextResponse.json(carts);
+  try {
+    const records = await readHistory();
+    const orders = records.filter(
+      (r) =>
+        r.type === 'order' &&
+        (!userId || String(r.userId) === String(userId))
+    );
+    return NextResponse.json(orders);
+  } catch (err) {
+    console.error('Failed to read orders', err);
+    return NextResponse.json(
+      { message: 'Failed to load orders' },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/api/quote/route.ts
+++ b/src/app/api/quote/route.ts
@@ -46,13 +46,14 @@ export async function POST(request: Request) {
     id: quoteId,
     userId: session?.user?.id ?? null,
     status: 'submitted',
+    type: 'quote' as const,
     ...parsed.data,
     createdAt: new Date().toISOString(),
   } as const;
   const baseDir = process.env.VERCEL
     ? '/tmp'
     : path.join(process.cwd(), 'data');
-  const filePath = path.join(baseDir, 'quotes.json');
+  const filePath = path.join(baseDir, 'user-history.json');
 
   try {
     await fs.mkdir(baseDir, { recursive: true });

--- a/src/app/api/quotes/[id]/route.ts
+++ b/src/app/api/quotes/[id]/route.ts
@@ -1,19 +1,19 @@
 import { NextResponse } from 'next/server';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
-import type { Quote } from '@/types';
+import type { HistoryRecord } from '@/types';
 
 export const dynamic = 'force-dynamic';
 
-async function readQuotes(): Promise<Quote[]> {
+async function readQuotes(): Promise<HistoryRecord[]> {
   const baseDir = process.env.VERCEL ? '/tmp' : path.join(process.cwd(), 'data');
-  const filePath = path.join(baseDir, 'quotes.json');
+  const filePath = path.join(baseDir, 'user-history.json');
   try {
     const data = await fs.readFile(filePath, 'utf8');
     return data
       .split('\n')
       .filter(Boolean)
-      .map((line) => JSON.parse(line) as Quote);
+      .map((line) => JSON.parse(line) as HistoryRecord);
   } catch (err: unknown) {
     const error = err as NodeJS.ErrnoException;
     if (error.code === 'ENOENT') {
@@ -33,7 +33,10 @@ export async function GET(
   try {
     const quotes = await readQuotes();
     const quote = quotes.find(
-      (q) => q.id === params.id && (!userId || String(q.userId) === String(userId))
+      (q) =>
+        q.type === 'quote' &&
+        q.id === params.id &&
+        (!userId || String(q.userId) === String(userId))
     );
     if (!quote) {
       return NextResponse.json({ message: 'Quote not found' }, { status: 404 });

--- a/src/app/api/quotes/route.ts
+++ b/src/app/api/quotes/route.ts
@@ -1,19 +1,19 @@
 import { NextResponse } from 'next/server';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
-import type { Quote } from '@/types';
+import type { HistoryRecord } from '@/types';
 
 export const dynamic = 'force-dynamic';
 
-async function readQuotes(): Promise<Quote[]> {
+async function readQuotes(): Promise<HistoryRecord[]> {
   const baseDir = process.env.VERCEL ? '/tmp' : path.join(process.cwd(), 'data');
-  const filePath = path.join(baseDir, 'quotes.json');
+  const filePath = path.join(baseDir, 'user-history.json');
   try {
     const data = await fs.readFile(filePath, 'utf8');
     return data
       .split('\n')
       .filter(Boolean)
-      .map((line) => JSON.parse(line) as Quote);
+      .map((line) => JSON.parse(line) as HistoryRecord);
   } catch (err: unknown) {
     const error = err as NodeJS.ErrnoException;
     if (error.code === 'ENOENT') {
@@ -29,9 +29,11 @@ export async function GET(request: Request) {
 
   try {
     const quotes = await readQuotes();
-    const filtered = userId
-      ? quotes.filter((q) => String(q.userId) === String(userId))
-      : quotes;
+    const filtered = quotes.filter(
+      (q) =>
+        q.type === 'quote' &&
+        (!userId || String(q.userId) === String(userId))
+    );
     return NextResponse.json(filtered);
   } catch (err) {
     console.error('Failed to read quotes', err);

--- a/src/app/order/success/success-client.tsx
+++ b/src/app/order/success/success-client.tsx
@@ -19,6 +19,11 @@ export default function OrderSuccessClient() {
       .then((s) => {
         setSession(s);
         setError(null);
+        fetch('/api/order', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ session: s }),
+        }).catch((err) => console.error('order record failed', err));
       })
       .catch(() => setError('Failed to load session'))
       .finally(() => setLoading(false));

--- a/src/components/OrderHistory.tsx
+++ b/src/components/OrderHistory.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import OrderTable from './OrderTable';
+import type { HistoryRecord } from '@/types';
+
+interface OrderHistoryProps {
+  emptyMessage?: string;
+}
+
+export default function OrderHistory({ emptyMessage }: OrderHistoryProps) {
+  const { data: session } = useSession();
+  const [orders, setOrders] = useState<HistoryRecord[]>([]);
+
+  useEffect(() => {
+    if (!session?.user?.id) return;
+    fetch(`/api/orders?userId=${session.user.id}`)
+      .then((res) => res.json())
+      .then((data: HistoryRecord[]) => setOrders(data))
+      .catch(() => setOrders([]));
+  }, [session?.user?.id]);
+
+  return (
+    <OrderTable
+      items={orders}
+      basePath="/account/orders"
+      idLabel="Order ID"
+      emptyMessage={emptyMessage}
+    />
+  );
+}
+

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -1,0 +1,21 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import type { HistoryRecord } from '@/types';
+
+export async function readHistory(): Promise<HistoryRecord[]> {
+  const baseDir = process.env.VERCEL ? '/tmp' : path.join(process.cwd(), 'data');
+  const filePath = path.join(baseDir, 'user-history.json');
+  try {
+    const data = await fs.readFile(filePath, 'utf8');
+    return data
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as HistoryRecord);
+  } catch (err: unknown) {
+    const error = err as NodeJS.ErrnoException;
+    if (error.code === 'ENOENT') {
+      return [];
+    }
+    throw err;
+  }
+}

--- a/types/history.ts
+++ b/types/history.ts
@@ -1,0 +1,14 @@
+export interface HistoryRecord {
+  id: string;
+  userId: string | number | null;
+  type: 'order' | 'quote';
+  status: string;
+  createdAt: string;
+  session?: import('./order').CheckoutSession;
+  cart?: { items: import('./order').CartItem[] };
+  user?: {
+    name?: string;
+    email?: string;
+    phone?: string;
+  };
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -26,3 +26,4 @@ export type Product = {
 
 export type { CartItem, CheckoutSession } from './order';
 export type { Quote } from './quote';
+export type { HistoryRecord } from './history';


### PR DESCRIPTION
## Summary
- Store checkout sessions via new `/api/order` and write both orders and quotes to a unified `user-history.json`
- Serve account history through `/api/orders` and `/api/quotes` backed by that file
- Persist order records after Stripe success and surface them in account pages
- Read history directly from disk in account views so placed orders and quotes appear

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_6891166e0e54832a9c1ec4746e89a292