### PR TITLE
feat: restore order details page

### DIFF
--- a/src/app/account/orders/[id]/page.tsx
+++ b/src/app/account/orders/[id]/page.tsx
@@ -26,7 +26,7 @@ async function getOrderDetails(id: string): Promise<OrderDetails | null> {
   const order = history.find(
     (r) =>
       r.type === 'order' &&
-      r.id === id &&
+      String(r.id) === String(id) &&
       String(r.userId) === String(session.user.id),
   );
   if (!order) {

--- a/src/app/account/orders/[id]/page.tsx
+++ b/src/app/account/orders/[id]/page.tsx
@@ -6,27 +6,63 @@ import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 import type { HistoryRecord } from '@/types';
 import { readHistory } from '@/lib/history';
+import AddToCartButton from '@/components/AddToCartButton';
+import { getProductByIdOrSlug } from '@/bff/services';
+import type { Product } from '@/types/order';
 
-async function getOrderDetails(id: string): Promise<HistoryRecord | null> {
+interface OrderDetails {
+  order: HistoryRecord;
+  products: Product[];
+  total: number;
+  totalProducts: number;
+}
+
+async function getOrderDetails(id: string): Promise<OrderDetails | null> {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
     return null;
   }
   const history = await readHistory();
-  return (
-    history.find(
-      (r) =>
-        r.type === 'order' &&
-        r.id === id &&
-        String(r.userId) === String(session.user.id),
-    ) ?? null
+  const order = history.find(
+    (r) =>
+      r.type === 'order' &&
+      r.id === id &&
+      String(r.userId) === String(session.user.id),
   );
+  if (!order) {
+    return null;
+  }
+
+  const items = order.cart?.items ?? [];
+  const products: Product[] = [];
+  for (const item of items) {
+    try {
+      const product = await getProductByIdOrSlug(item.productId);
+      const discount = product.discountPercentage ?? 0;
+      const discountedPrice = Number(
+        (product.price * (1 - discount / 100)).toFixed(2),
+      );
+      products.push({
+        id: product.id,
+        title: product.title,
+        price: product.price,
+        quantity: item.quantity,
+        total: product.price * item.quantity,
+        discountPercentage: discount,
+        discountedPrice,
+      });
+    } catch (err) {
+      console.error('Failed to fetch product details', err);
+    }
+  }
+  const total = products.reduce((sum, p) => sum + p.total, 0);
+  return { order, products, total, totalProducts: products.length };
 }
 
 export default async function OrderDetailPage({ params }: { params: { id: string } }) {
-  const order = await getOrderDetails(params.id);
+  const details = await getOrderDetails(params.id);
 
-  if (!order) {
+  if (!details) {
     return (
       <AuthGuard>
         <div className="container mx-auto px-4 py-8">
@@ -41,6 +77,8 @@ export default async function OrderDetailPage({ params }: { params: { id: string
     );
   }
 
+  const { order, products, total, totalProducts } = details;
+
   return (
     <AuthGuard>
       <div className="container mx-auto px-4 py-8">
@@ -49,9 +87,37 @@ export default async function OrderDetailPage({ params }: { params: { id: string
         {order.session?.customer?.name && (
           <p className="mb-4">Customer: {order.session.customer.name}</p>
         )}
-        <Link href="/account" className="text-blue-500 hover:underline">
-          Back to My Account
-        </Link>
+        <div className="bg-white p-6 rounded-lg shadow mb-6">
+          <p>
+            <strong>Total Items:</strong> {totalProducts}
+          </p>
+          <p>
+            <strong>Total Amount:</strong> ${total.toFixed(2)}
+          </p>
+        </div>
+        <div className="bg-white p-6 rounded-lg shadow">
+          <div className="flex justify-between items-center mb-2">
+            <h2 className="text-xl font-semibold">Products</h2>
+            <AddToCartButton products={products} />
+          </div>
+          <ul>
+            {products.map((product) => (
+              <li key={product.id} className="border-b last:border-b-0 py-2">
+                <p>
+                  <strong>{product.title}</strong>
+                </p>
+                <p>Price: ${product.price}</p>
+                <p>Quantity: {product.quantity}</p>
+                <p>Total: ${product.total.toFixed(2)}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <p className="mt-6">
+          <Link href="/account" className="text-blue-500 hover:underline">
+            Back to My Account
+          </Link>
+        </p>
       </div>
     </AuthGuard>
   );


### PR DESCRIPTION
## Summary
- fetch full product details for order items
- show totals and add all-to-cart button on order page

## Testing
- `pnpm test run`

------
https://chatgpt.com/codex/tasks/task_e_68912b634e00832aa7001c2c1da2055f