### PR TITLE
feat: improve accessibility and focus styles

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -99,7 +99,10 @@ export default async function HomePage() {
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6 md:gap-8">
               {categoriesToDisplay.map((category) => (
                 <Link key={category.slug} href={`/category/${category.slug}`} legacyBehavior>
-                  <a className="group block bg-white rounded-lg shadow-lg hover:shadow-2xl transition-shadow duration-300 overflow-hidden">
+                  <a
+                    className="group block bg-white rounded-lg shadow-lg hover:shadow-2xl transition-shadow duration-300 overflow-hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent"
+                    aria-label={`View ${category.name} category`}
+                  >
                     <div className="aspect-w-1 aspect-h-1 w-full relative"> {/* Added relative positioning for Image fill */}
                       {category.imageUrl && (
                         <Image

--- a/src/components/HeroBanner.tsx
+++ b/src/components/HeroBanner.tsx
@@ -16,7 +16,7 @@ export default function HeroBanner({ title, description, ctaText, ctaLink, image
             <div className="mt-8">
               <a
                 href={ctaLink}
-                className="inline-block bg-accent text-secondary font-bold py-3 px-8 rounded-md hover:bg-accent-dark transition-colors duration-300"
+                className="inline-block bg-accent text-secondary font-bold py-3 px-8 rounded-md hover:bg-accent-dark transition-colors duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent-dark"
               >
                 {ctaText}
               </a>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -208,11 +208,12 @@ export default function NavBar({ initialCategories, categoryError }: NavBarProps
                       </Transition>
                     </Menu>
                   ) : (
-                    <Link href="/login" passHref>
-                      <button type="button" className="rounded-full bg-secondary p-1 text-primary hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-secondary" title="Login / My Account">
-                        <span className="sr-only">Login / My Account</span>
-                        <UserCircleIcon className="h-6 w-6" aria-hidden="true" />
-                      </button>
+                    <Link
+                      href="/login"
+                      className="rounded-full bg-secondary p-1 text-primary hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-secondary"
+                      aria-label="Login / My Account"
+                    >
+                      <UserCircleIcon className="h-6 w-6" aria-hidden="true" />
                     </Link>
                   )}
                 </div>

--- a/src/components/PopularProductsCarouselClient.tsx
+++ b/src/components/PopularProductsCarouselClient.tsx
@@ -80,7 +80,8 @@ export default function PopularProductsCarouselClient({ products }: Props) {
         onClick={() => scrollBy(-250)}
         aria-controls="popular-carousel"
         aria-disabled={!canPrev}
-        className={`hidden md:flex absolute left-0 top-1/2 -translate-y-1/2 bg-white dark:bg-gray-700 p-2 rounded-full shadow ${!canPrev ? 'opacity-40 pointer-events-none' : ''}`}
+        disabled={!canPrev}
+        className={`hidden md:flex absolute left-0 top-1/2 -translate-y-1/2 bg-white dark:bg-gray-700 p-2 rounded-full shadow ${!canPrev ? 'opacity-40 pointer-events-none' : ''} focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent`}
       >
         <span className="sr-only">Previous products</span>
         <ChevronLeft className="h-5 w-5" />
@@ -90,7 +91,8 @@ export default function PopularProductsCarouselClient({ products }: Props) {
         onClick={() => scrollBy(250)}
         aria-controls="popular-carousel"
         aria-disabled={!canNext}
-        className={`hidden md:flex absolute right-0 top-1/2 -translate-y-1/2 bg-white dark:bg-gray-700 p-2 rounded-full shadow ${!canNext ? 'opacity-40 pointer-events-none' : ''}`}
+        disabled={!canNext}
+        className={`hidden md:flex absolute right-0 top-1/2 -translate-y-1/2 bg-white dark:bg-gray-700 p-2 rounded-full shadow ${!canNext ? 'opacity-40 pointer-events-none' : ''} focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent`}
       >
         <span className="sr-only">Next products</span>
         <ChevronRight className="h-5 w-5" />


### PR DESCRIPTION
## Summary
- improve hero banner CTA keyboard visibility
- add accessible login link
- enhance carousel nav buttons and category card focus styles

## Testing
- `npm run lint:accessibility` *(fails: Missing script "lint:accessibility")*
- `CI=true npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891c507756c832ab2c4b5d0aca7d6b5