### PR TITLE
Add companyId to auth session

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ The Quick Order page lets authenticated B2B users add multiple products to the c
 ## Role logic
 Authentication includes a `role` field (`b2b` or `b2c`). B2B roles expose features like Quick Order and Request Quote, while B2C users proceed directly to checkout.
 
+## Auth session
+The authenticated session also exposes a `companyId` derived from the user's company name. Both `role` and `companyId` are available via `useSession()`:
+
+```ts
+{
+  user: { id: '1', role: 'b2b', companyId: 'acme-inc' },
+  role: 'b2b',
+  companyId: 'acme-inc'
+}
+```
+
 ## Environment variables
 | Variable | Purpose |
 | --- | --- |

--- a/__tests__/auth.test.ts
+++ b/__tests__/auth.test.ts
@@ -29,4 +29,33 @@ describe('auth session companyId', () => {
     expect(session.companyId).toBe(expectedSlug);
     expect(session.user.companyId).toBe(expectedSlug);
   });
+
+  it('handles special characters in company name', async () => {
+    const user = {
+      id: '2',
+      accessToken: 'token',
+      company: { name: 'Müller & Søn AS' },
+    };
+
+    const token = await runJwtCallback(user);
+    expect(token.companyId).toBe('muller-son-as');
+
+    const session = await runSessionCallback(token);
+    expect(session.companyId).toBe('muller-son-as');
+    expect(session.user.companyId).toBe('muller-son-as');
+  });
+
+  it('defaults companyId when company is missing', async () => {
+    const user = {
+      id: '3',
+      accessToken: 'token',
+    };
+
+    const token = await runJwtCallback(user);
+    expect(token.companyId).toBe('unknown-company');
+
+    const session = await runSessionCallback(token);
+    expect(session.companyId).toBe('unknown-company');
+    expect(session.user.companyId).toBe('unknown-company');
+  });
 });

--- a/__tests__/auth.test.ts
+++ b/__tests__/auth.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { authOptions } from '@/lib/auth';
+
+// Utility to simulate NextAuth callbacks
+function runJwtCallback(user: any) {
+  return authOptions.callbacks!.jwt!({ token: {}, user } as any);
+}
+
+function runSessionCallback(token: any) {
+  return authOptions.callbacks!.session!({ session: { user: {} } as any, token } as any);
+}
+
+describe('auth session companyId', () => {
+  it('adds companyId slug from user.company.name', async () => {
+    const user = {
+      id: '1',
+      accessToken: 'token',
+      company: { name: 'Acme Inc' },
+    };
+
+    const token = await runJwtCallback(user);
+    expect(token.companyId).toBe('acme-inc');
+
+    const session = await runSessionCallback(token);
+    expect(session.companyId).toBe('acme-inc');
+    expect(session.user.companyId).toBe('acme-inc');
+  });
+});

--- a/__tests__/auth.test.ts
+++ b/__tests__/auth.test.ts
@@ -1,13 +1,16 @@
 import { describe, it, expect } from 'vitest';
+import type { Session, User } from 'next-auth';
+import type { JWT } from 'next-auth/jwt';
 import { authOptions } from '@/lib/auth';
+import { slugify } from '@/lib/utils';
 
 // Utility to simulate NextAuth callbacks
-function runJwtCallback(user: any) {
-  return authOptions.callbacks!.jwt!({ token: {}, user } as any);
+function runJwtCallback(user: Partial<User>) {
+  return authOptions.callbacks!.jwt!({ token: {} as JWT, user: user as User });
 }
 
-function runSessionCallback(token: any) {
-  return authOptions.callbacks!.session!({ session: { user: {} } as any, token } as any);
+function runSessionCallback(token: Partial<JWT>) {
+  return authOptions.callbacks!.session!({ session: { user: {} } as Session, token: token as JWT });
 }
 
 describe('auth session companyId', () => {
@@ -19,10 +22,11 @@ describe('auth session companyId', () => {
     };
 
     const token = await runJwtCallback(user);
-    expect(token.companyId).toBe('acme-inc');
+    const expectedSlug = slugify(user.company!.name!);
+    expect(token.companyId).toBe(expectedSlug);
 
     const session = await runSessionCallback(token);
-    expect(session.companyId).toBe('acme-inc');
-    expect(session.user.companyId).toBe('acme-inc');
+    expect(session.companyId).toBe(expectedSlug);
+    expect(session.user.companyId).toBe(expectedSlug);
   });
 });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -65,7 +65,6 @@ export const authOptions: NextAuthOptions = {
           });
 
           if (userFromBff && userFromBff.accessToken) {
-            console.log('Auth: User authorized by BFF:', userFromBff);
             return {
               id: String(userFromBff.id),
               name: [userFromBff.firstName, userFromBff.lastName].filter(Boolean).join(' ') || userFromBff.username,
@@ -95,7 +94,7 @@ export const authOptions: NextAuthOptions = {
         token.accessToken = user.accessToken;
         token.id = user.id;
         token.role = 'b2b';
-        const companyName = (user as any)?.company?.name;
+        const companyName = (user as NextAuthUser & { company?: { name?: string } })?.company?.name;
         if (companyName) {
           token.companyId = slugify(companyName);
         }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -94,9 +94,12 @@ export const authOptions: NextAuthOptions = {
         token.accessToken = user.accessToken;
         token.id = user.id;
         token.role = 'b2b';
-        const companyName = (user as NextAuthUser & { company?: { name?: string } })?.company?.name;
+        const companyName = (user as NextAuthUser & { company?: { name?: string } })?.company?.name?.trim();
         if (companyName) {
           token.companyId = slugify(companyName);
+        } else {
+          token.companyId = 'unknown-company';
+          console.warn('[auth] user has no company; defaulting companyId to "unknown-company"');
         }
       }
       return token;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -3,9 +3,12 @@ export function slugify(text: string): string {
   if (!text) return '';
   return text
     .toString()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '') // Remove diacritics
+    .replace(/ø/gi, 'o') // Handle special Nordic characters
     .toLowerCase()
     .trim()
     .replace(/\s+/g, '-') // Replace spaces with -
-    .replace(/[^\w-]+/g, '') // Remove all non-word chars
+    .replace(/[^a-z0-9-]+/g, '') // Remove all non-word chars
     .replace(/--+/g, '-'); // Replace multiple - with single -
 }


### PR DESCRIPTION
## Summary
- slugify DummyJSON user company name and store as `companyId` in JWT and session
- expose `companyId` via `useSession` and update NextAuth types
- add unit test ensuring `session.companyId` matches slugified company name

## Testing
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_6891d8977c5c832aa6c238995510d250