### PR TITLE
feat: add company provider context

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { Suspense } from 'react';
 // import { unstable_noStore as noStore } from 'next/cache'; // Remove if using revalidate
 import { Toaster } from 'react-hot-toast'; // Import Toaster
 import RootClientProviders from '@/components/RootClientProviders';
+import { CompanyProvider } from '@/contexts/CompanyProvider';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -47,13 +48,15 @@ export default async function RootLayout({
     <html lang="en">
       <body className={inter.className}>
         <RootClientProviders>
-          <Toaster position="top-center" reverseOrder={false} />
-          <Suspense fallback={null}>
-            <NavBar initialCategories={categoriesForNav} categoryError={categoryError} />
-          </Suspense>
-          <main className="mx-auto max-w-7xl px-2 sm:px-6 lg:px-8 py-6">
-            {children}
-          </main>
+          <CompanyProvider>
+            <Toaster position="top-center" reverseOrder={false} />
+            <Suspense fallback={null}>
+              <NavBar initialCategories={categoriesForNav} categoryError={categoryError} />
+            </Suspense>
+            <main className="mx-auto max-w-7xl px-2 sm:px-6 lg:px-8 py-6">
+              {children}
+            </main>
+          </CompanyProvider>
         </RootClientProviders>
       </body>
     </html>

--- a/src/contexts/CompanyProvider.stories.tsx
+++ b/src/contexts/CompanyProvider.stories.tsx
@@ -1,0 +1,50 @@
+'use client';
+import { SessionProvider } from 'next-auth/react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { CompanyProvider, useCompany } from './CompanyProvider';
+
+const RoleBadges = () => {
+  const company = useCompany();
+  if (!company) return <div>Unauthenticated</div>;
+  return (
+    <div className="flex gap-2">
+      {company.isBuyer && <span className="px-2 py-1 bg-blue-200 rounded">Buyer</span>}
+      {company.isApprover && <span className="px-2 py-1 bg-green-200 rounded">Approver</span>}
+      {company.isAdmin && <span className="px-2 py-1 bg-red-200 rounded">Admin</span>}
+    </div>
+  );
+};
+
+const meta: Meta<typeof RoleBadges> = {
+  title: 'Contexts/CompanyProvider',
+  component: RoleBadges,
+  decorators: [
+    (Story, { parameters }) => (
+      <SessionProvider session={parameters.session}>
+        <CompanyProvider>
+          <Story />
+        </CompanyProvider>
+      </SessionProvider>
+    )
+  ],
+  parameters: {
+    session: { user: { role: 'buyer', companyId: 'acme-inc' } }
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Buyer: Story = {
+  parameters: { session: { user: { role: 'buyer', companyId: 'acme-inc' } } }
+};
+
+export const Approver: Story = {
+  parameters: { session: { user: { role: 'approver', companyId: 'acme-inc' } } }
+};
+
+export const Admin: Story = {
+  parameters: { session: { user: { role: 'admin', companyId: 'acme-inc' } } }
+};
+

--- a/src/contexts/CompanyProvider.tsx
+++ b/src/contexts/CompanyProvider.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+import { useSession } from 'next-auth/react';
+
+export interface CompanyContextValue {
+  companyId: string;
+  role: string;
+  isBuyer: boolean;
+  isApprover: boolean;
+  isAdmin: boolean;
+}
+
+const CompanyContext = createContext<CompanyContextValue | null>(null);
+
+export function CompanyProvider({ children }: { children: React.ReactNode }) {
+  const { data: session } = useSession();
+  const companyId = session?.companyId || session?.user?.companyId;
+  const role = session?.role || session?.user?.role;
+
+  const value = companyId && role
+    ? {
+        companyId,
+        role,
+        isBuyer: role === 'buyer',
+        isApprover: role === 'approver',
+        isAdmin: role === 'admin',
+      }
+    : null;
+
+  return (
+    <CompanyContext.Provider value={value}>{children}</CompanyContext.Provider>
+  );
+}
+
+export function useCompany() {
+  return useContext(CompanyContext);
+}
+


### PR DESCRIPTION
## Summary
- add CompanyProvider for role & company info
- wrap app layout with CompanyProvider
- add Storybook example showing role badges

## Testing
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_6891e294abc8832aa5b4b195d9cbda73