### PR TITLE
Fix inconsistent product tile heights in carousel

### DIFF
--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -30,9 +30,9 @@ export default function ProductCard({ product, highlightTerm }: ProductCardProps
               />
             </div>
           )}
-          <h3 className="mt-4 text-lg font-semibold text-gray-900 group-hover:text-blue-600">
-            {highlight(product.title, highlightTerm ?? '')}
-          </h3>
+            <h3 className="mt-4 text-lg font-semibold text-gray-900 group-hover:text-blue-600 h-14 overflow-hidden">
+              {highlight(product.title, highlightTerm ?? '')}
+            </h3>
         </Link>
         <p className="mt-1 text-sm text-gray-600 h-10 overflow-hidden text-ellipsis">
           {product.description}

--- a/styles/FeaturedProductsCarousel.module.css
+++ b/styles/FeaturedProductsCarousel.module.css
@@ -27,6 +27,8 @@
   margin-top: 0.5rem; /* Add some space above name */
   margin-bottom: 0.25rem; /* Add some space below name */
   font-size: 1.1rem; /* Slightly larger font for name */
+  height: 3rem; /* Reserve space for up to two lines */
+  overflow: hidden; /* Prevent tall titles from stretching the card */
 }
 
 .productCard p {


### PR DESCRIPTION
## Summary
- Fix product card title height using Tailwind to keep carousel tiles uniform
- Add fixed height and overflow handling to FeaturedProductsCarousel titles

## Testing
- `CI=1 pnpm test --reporter=basic`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_689e3fe0d484832a91eb24a4f5b9f2d1