### PR TITLE
feat: add store pickup availability

### DIFF
--- a/data/mockStoreStock.json
+++ b/data/mockStoreStock.json
@@ -1,0 +1,20 @@
+[
+  {
+    "storeId": "oslo",
+    "storeName": "Oslo City",
+    "address": "Karl Johans gate 1, Oslo",
+    "stock": 5
+  },
+  {
+    "storeId": "bergen",
+    "storeName": "Bergen Sentrum",
+    "address": "Bryggen 1, Bergen",
+    "stock": 0
+  },
+  {
+    "storeId": "trondheim",
+    "storeName": "Trondheim Torg",
+    "address": "Kongens gate 9, Trondheim",
+    "stock": 2
+  }
+]

--- a/src/app/api/stock/[id]/route.ts
+++ b/src/app/api/stock/[id]/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import mockData from '@root/data/mockStoreStock.json';
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { id: string } }
+) {
+  const stockApi = process.env.STOCK_API_URL;
+  if (stockApi) {
+    try {
+      const res = await fetch(`${stockApi}/${params.id}`);
+      if (res.ok) {
+        const data = await res.json();
+        return NextResponse.json(data);
+      }
+    } catch (err) {
+      console.error('Failed to fetch stock data', err);
+    }
+  }
+  // Fallback to mock data
+  return NextResponse.json(mockData);
+}

--- a/src/app/product/[slug]/page.tsx
+++ b/src/app/product/[slug]/page.tsx
@@ -11,6 +11,7 @@ import ProductGallery from '@/components/ProductGallery'; // Changed from Galler
 import PriceBox from '@/components/PriceBox';
 import CopyLinkButton from '@/components/CopyLinkButton';
 import WishlistButton from '@/components/WishlistButton';
+import PickupInStore from '@/components/PickupInStore';
 import { useCartStore } from '@/stores/useCartStore'; // Import cart store
 import toast from 'react-hot-toast'; // For feedback
 import { useEffect, useState } from 'react'; // For client-side data fetching
@@ -155,6 +156,7 @@ export default function ProductPage() {
             </button>
             <WishlistButton product={product} />
             <CopyLinkButton />
+            <PickupInStore productId={product.id} />
           </div>
         </div>
       </div>

--- a/src/components/PickupInStore.test.tsx
+++ b/src/components/PickupInStore.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import PickupInStore from './PickupInStore';
+
+const mockStores = [
+  { storeId: '1', storeName: 'Test Store', address: '123 Main St', stock: 2 }
+];
+
+describe('PickupInStore', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockStores)
+    }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('loads store availability when button clicked', async () => {
+    render(<PickupInStore productId={1} />);
+    fireEvent.click(screen.getByRole('button', { name: /check availability/i }));
+    await waitFor(() => {
+      expect(screen.getByText('Test Store')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/PickupInStore.test.tsx
+++ b/src/components/PickupInStore.test.tsx
@@ -25,4 +25,15 @@ describe('PickupInStore', () => {
       expect(screen.getByText('Test Store')).toBeInTheDocument();
     });
   });
+
+  it('closes store availability when close button clicked', async () => {
+    render(<PickupInStore productId={1} />);
+    fireEvent.click(screen.getByRole('button', { name: /check availability/i }));
+    await waitFor(() => {
+      expect(screen.getByText('Test Store')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(screen.queryByText('Test Store')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /check availability/i })).toBeInTheDocument();
+  });
 });

--- a/src/components/PickupInStore.tsx
+++ b/src/components/PickupInStore.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+
+interface StoreAvailability {
+  storeId: string;
+  storeName: string;
+  address: string;
+  stock: number;
+}
+
+interface Props {
+  productId: number | string;
+}
+
+export default function PickupInStore({ productId }: Props) {
+  const [stores, setStores] = useState<StoreAvailability[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAvailability = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/stock/${productId}`);
+      if (!res.ok) throw new Error('Network response was not ok');
+      const data = (await res.json()) as StoreAvailability[];
+      setStores(data);
+      setError(null);
+    } catch {
+      setError('Unable to load store availability');
+      setStores(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="mt-6">
+      <h3 className="text-xl font-semibold text-gray-900 mb-2">Pick up in store</h3>
+      {stores ? (
+        <ul className="border border-gray-200 rounded-md divide-y divide-gray-200">
+          {stores.map((store) => (
+            <li key={store.storeId} className="p-4 flex justify-between">
+              <div>
+                <p className="font-medium text-gray-900">{store.storeName}</p>
+                <p className="text-sm text-gray-500">{store.address}</p>
+              </div>
+              <span
+                className={
+                  store.stock > 0
+                    ? 'text-sm font-medium text-green-600'
+                    : 'text-sm font-medium text-red-600'
+                }
+              >
+                {store.stock > 0 ? `${store.stock} in stock` : 'Out of stock'}
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <>
+          {error && <p className="text-sm text-red-600 mb-2">{error}</p>}
+          <button
+            type="button"
+            onClick={fetchAvailability}
+            disabled={loading}
+            className="w-full bg-gray-100 text-gray-900 py-3 px-6 rounded-md hover:bg-gray-200 disabled:opacity-50"
+          >
+            {loading ? 'Checking availability...' : 'Check availability in store'}
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/PickupInStore.tsx
+++ b/src/components/PickupInStore.tsx
@@ -36,25 +36,34 @@ export default function PickupInStore({ productId }: Props) {
     <div className="mt-6">
       <h3 className="text-xl font-semibold text-gray-900 mb-2">Pick up in store</h3>
       {stores ? (
-        <ul className="border border-gray-200 rounded-md divide-y divide-gray-200">
-          {stores.map((store) => (
-            <li key={store.storeId} className="p-4 flex justify-between">
-              <div>
-                <p className="font-medium text-gray-900">{store.storeName}</p>
-                <p className="text-sm text-gray-500">{store.address}</p>
-              </div>
-              <span
-                className={
-                  store.stock > 0
-                    ? 'text-sm font-medium text-green-600'
-                    : 'text-sm font-medium text-red-600'
-                }
-              >
-                {store.stock > 0 ? `${store.stock} in stock` : 'Out of stock'}
-              </span>
-            </li>
-          ))}
-        </ul>
+        <>
+          <ul className="border border-gray-200 rounded-md divide-y divide-gray-200">
+            {stores.map((store) => (
+              <li key={store.storeId} className="p-4 flex justify-between">
+                <div>
+                  <p className="font-medium text-gray-900">{store.storeName}</p>
+                  <p className="text-sm text-gray-500">{store.address}</p>
+                </div>
+                <span
+                  className={
+                    store.stock > 0
+                      ? 'text-sm font-medium text-green-600'
+                      : 'text-sm font-medium text-red-600'
+                  }
+                >
+                  {store.stock > 0 ? `${store.stock} in stock` : 'Out of stock'}
+                </span>
+              </li>
+            ))}
+          </ul>
+          <button
+            type="button"
+            onClick={() => setStores(null)}
+            className="mt-4 w-full bg-gray-100 text-gray-900 py-3 px-6 rounded-md hover:bg-gray-200"
+          >
+            Close
+          </button>
+        </>
       ) : (
         <>
           {error && <p className="text-sm text-red-600 mb-2">{error}</p>}


### PR DESCRIPTION
## Summary
- add API route for product store stock with fallback mock data
- create PickupInStore component and integrate into product page
- cover pickup component with test

## Testing
- `pnpm lint`
- `pnpm test run`


------
https://chatgpt.com/codex/tasks/task_e_68abf4ebd7b0832a9d933b178ae0d5e0