### PR TITLE
feat: add pickup in store option

### DIFF
--- a/src/app/(protected)/quick-order/QuickOrderForm.tsx
+++ b/src/app/(protected)/quick-order/QuickOrderForm.tsx
@@ -57,10 +57,7 @@ export default function QuickOrderForm() {
       }
       try {
         const product = await getProductByIdOrSlug(sku);
-        if (!setFulfillment({ type: 'delivery' })) {
-          updatedRows[i].error = 'Cart reserved for pickup';
-          continue;
-        }
+        setFulfillment({ type: 'delivery' });
         addItem(product, quantity);
       } catch {
         updatedRows[i].error = 'Invalid SKU';

--- a/src/app/(protected)/quick-order/QuickOrderForm.tsx
+++ b/src/app/(protected)/quick-order/QuickOrderForm.tsx
@@ -12,6 +12,7 @@ interface Row {
 
 export default function QuickOrderForm() {
   const addItem = useCartStore((state) => state.addItem);
+  const setFulfillment = useCartStore((state) => state.setFulfillment);
   const [rows, setRows] = useState<Row[]>([
     { sku: '', quantity: 1 },
     { sku: '', quantity: 1 },
@@ -56,6 +57,10 @@ export default function QuickOrderForm() {
       }
       try {
         const product = await getProductByIdOrSlug(sku);
+        if (!setFulfillment({ type: 'delivery' })) {
+          updatedRows[i].error = 'Cart reserved for pickup';
+          continue;
+        }
         addItem(product, quantity);
       } catch {
         updatedRows[i].error = 'Invalid SKU';

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -15,10 +15,11 @@ import { createCheckoutSession } from '@/lib/services/dummyjson';
 export default function CartPage() {
   // Subscribe to cart store state and actions
   const items = useCartStore((state) => state.items);
-  const updateItemQuantity = useCartStore((state) => state.updateItemQuantity);
+  const updateItemQuantity = useCartStore((state) => state.updateQuantity);
   const removeItem = useCartStore((state) => state.removeItem);
   const getCartSubtotal = useCartStore((state) => state.getCartSubtotal);
   const clearCart = useCartStore((state) => state.clearCart); // For "Clear Cart" button
+  const fulfillment = useCartStore((state) => state.fulfillment);
 
   const { data: session } = useSession();
   const router = useRouter();
@@ -217,6 +218,11 @@ export default function CartPage() {
                 <div className="flex items-center justify-between border-t border-gray-200 pt-4">
                   <dt className="text-base font-medium text-gray-900">Order total</dt>
                   <dd className="text-base font-medium text-gray-900">${subtotal.toFixed(2)}</dd>
+                </div>
+                <div className="pt-4 text-sm text-gray-700">
+                  {fulfillment?.type === 'pickup'
+                    ? `Pickup in store: ${fulfillment.store?.storeName}`
+                    : 'Home delivery'}
                 </div>
               </dl>
 

--- a/src/app/order/success/success-client.tsx
+++ b/src/app/order/success/success-client.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { getCheckoutSession } from '@/bff/services/stripe';
 import type { CheckoutSession } from '@/types/order';
+import { useCartStore } from '@/stores/useCartStore';
+import { useRef } from 'react';
 
 export default function OrderSuccessClient() {
   const params = useSearchParams();
@@ -11,6 +13,8 @@ export default function OrderSuccessClient() {
   const [session, setSession] = useState<CheckoutSession | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const fulfillmentRef = useRef(useCartStore.getState().fulfillment);
+  const clearCart = useCartStore((state) => state.clearCart);
 
   useEffect(() => {
     if (!sessionId) return;
@@ -29,6 +33,10 @@ export default function OrderSuccessClient() {
       .finally(() => setLoading(false));
   }, [sessionId]);
 
+  useEffect(() => {
+    clearCart();
+  }, [clearCart]);
+
   if (!sessionId) {
     return <div className="container mx-auto px-4 py-8 text-center">Missing session ID.</div>;
   }
@@ -45,6 +53,11 @@ export default function OrderSuccessClient() {
     <div className="container mx-auto px-4 py-8 text-center">
       <h1 className="text-2xl font-semibold mb-4">Thanks {session.customer_details?.name || session.customer?.name || 'customer'}!</h1>
       <p className="mb-6">Order #{session.id} confirmed.</p>
+      {fulfillmentRef.current?.type === 'pickup' ? (
+        <p className="mb-6">Pickup in store: {fulfillmentRef.current.store?.storeName}</p>
+      ) : (
+        <p className="mb-6">Home delivery</p>
+      )}
       <Link href="/" className="text-blue-600 hover:underline">Back to store</Link>
     </div>
   );

--- a/src/app/product/[slug]/page.tsx
+++ b/src/app/product/[slug]/page.tsx
@@ -60,10 +60,7 @@ export default function ProductPage() {
       toast.error('Product data not available to add to cart.');
       return;
     }
-    if (!setFulfillment({ type: 'delivery' })) {
-      toast.error('Cart already reserved for pickup. Clear cart to switch to delivery.');
-      return;
-    }
+    setFulfillment({ type: 'delivery' });
     addItemToCart(product, 1);
     toast.success(`${product.title} added to cart!`);
   };

--- a/src/app/product/[slug]/page.tsx
+++ b/src/app/product/[slug]/page.tsx
@@ -30,6 +30,7 @@ export default function ProductPage() {
   const [error, setError] = useState<string | null>(null);
 
   const addItemToCart = useCartStore((state) => state.addItem);
+  const setFulfillment = useCartStore((state) => state.setFulfillment);
 
   useEffect(() => {
     if (slug) {
@@ -55,12 +56,16 @@ export default function ProductPage() {
   }, [slug]);
 
   const handleAddToCart = () => {
-    if (product) {
-      addItemToCart(product, 1);
-      toast.success(`${product.title} added to cart!`);
-    } else {
+    if (!product) {
       toast.error('Product data not available to add to cart.');
+      return;
     }
+    if (!setFulfillment({ type: 'delivery' })) {
+      toast.error('Cart already reserved for pickup. Clear cart to switch to delivery.');
+      return;
+    }
+    addItemToCart(product, 1);
+    toast.success(`${product.title} added to cart!`);
   };
 
   let productLdJsonScript = null;
@@ -156,7 +161,7 @@ export default function ProductPage() {
             </button>
             <WishlistButton product={product} />
             <CopyLinkButton />
-            <PickupInStore productId={product.id} />
+            <PickupInStore product={product} />
           </div>
         </div>
       </div>

--- a/src/components/AddToCartButton.tsx
+++ b/src/components/AddToCartButton.tsx
@@ -11,16 +11,18 @@ interface AddToCartButtonProps {
 }
 
 const AddToCartButton: React.FC<AddToCartButtonProps> = ({ products }) => {
-  const { addItem } = useCartStore();
+  const { addItem, setFulfillment } = useCartStore();
 
   const handleAddToCart = async () => {
+    if (!setFulfillment({ type: 'delivery' })) {
+      toast.error('Cart contains pickup items. Clear cart to add delivery items.');
+      return;
+    }
     let success = true;
     for (const orderProduct of products) {
       try {
         const fullProduct = await fetchProductById(orderProduct.id);
         if (fullProduct) {
-          // The cart store expects a product object that matches ProductSchema.
-          // The quantity comes from the original order.
           addItem(fullProduct, orderProduct.quantity);
         } else {
           success = false;

--- a/src/components/AddToCartButton.tsx
+++ b/src/components/AddToCartButton.tsx
@@ -14,10 +14,7 @@ const AddToCartButton: React.FC<AddToCartButtonProps> = ({ products }) => {
   const { addItem, setFulfillment } = useCartStore();
 
   const handleAddToCart = async () => {
-    if (!setFulfillment({ type: 'delivery' })) {
-      toast.error('Cart contains pickup items. Clear cart to add delivery items.');
-      return;
-    }
+    setFulfillment({ type: 'delivery' });
     let success = true;
     for (const orderProduct of products) {
       try {

--- a/src/components/PickupInStore.tsx
+++ b/src/components/PickupInStore.tsx
@@ -64,10 +64,7 @@ export default function PickupInStore({ product }: Props) {
                   <button
                     type="button"
                     onClick={() => {
-                      if (!setFulfillment({ type: 'pickup', store })) {
-                        toast.error('Cart has items for delivery or another store');
-                        return;
-                      }
+                      setFulfillment({ type: 'pickup', store });
                       addItem(product, 1);
                       toast.success(`Added for pickup at ${store.storeName}`);
                     }}

--- a/src/components/PriceBox.tsx
+++ b/src/components/PriceBox.tsx
@@ -47,10 +47,7 @@ export default function PriceBox({ product, role }: PriceBoxProps) {
   };
 
   const handleAddToCart = () => {
-    if (!setFulfillment({ type: 'delivery' })) {
-      toast.error('Cart reserved for pickup. Clear cart to add delivery items.');
-      return;
-    }
+    setFulfillment({ type: 'delivery' });
     addItemToCart(product, quantity);
     toast.success(`Added ${quantity} x ${product.title} to cart!`);
   };

--- a/src/components/PriceBox.tsx
+++ b/src/components/PriceBox.tsx
@@ -14,6 +14,7 @@ interface PriceBoxProps {
 export default function PriceBox({ product, role }: PriceBoxProps) {
   const [quantity, setQuantity] = useState(1);
   const addItemToCart = useCartStore((state) => state.addItem); // Get addItem action
+  const setFulfillment = useCartStore((state) => state.setFulfillment);
 
   const originalPrice = product.price.toFixed(2);
   const effectivePriceAmount = applyB2BPrice(product.price, role);
@@ -46,6 +47,10 @@ export default function PriceBox({ product, role }: PriceBoxProps) {
   };
 
   const handleAddToCart = () => {
+    if (!setFulfillment({ type: 'delivery' })) {
+      toast.error('Cart reserved for pickup. Clear cart to add delivery items.');
+      return;
+    }
     addItemToCart(product, quantity);
     toast.success(`Added ${quantity} x ${product.title} to cart!`);
   };

--- a/src/stores/useCartStore.test.ts
+++ b/src/stores/useCartStore.test.ts
@@ -41,7 +41,7 @@ const mockProduct2: z.infer<typeof ProductSchema> = {
 // Helper to get the raw string that would be stored by persist middleware
 // This is a simplified version; actual serialization might include versioning.
 // The key part is that `state` contains `items` and `lastUpdated`.
-const getPersistedStateString = (state: { items: CartItem[], lastUpdated: number | null }) => {
+const getPersistedStateString = (state: { items: CartItem[], lastUpdated: number | null, fulfillment: any }) => {
   return JSON.stringify({ state, version: 0 }); // Zustand persist typically includes a version
 };
 
@@ -157,6 +157,7 @@ describe('useCartStore with localStorage persistence', () => {
         { product: mockProduct2, quantity: 1 },
       ],
       lastUpdated: freshTimestamp,
+      fulfillment: { type: 'delivery' },
     };
     localStorage.setItem('cart_v1', getPersistedStateString(cartStateWithItems));
     // Clear setItem history from any previous (e.g. beforeEach) operations.
@@ -194,7 +195,8 @@ describe('useCartStore with localStorage persistence', () => {
     // 1. Simulate an expired cart in localStorage
     const expiredCartStateForStorage = {
       items: [{ product: mockProduct1, quantity: 1 }],
-      lastUpdated: expiredTimestamp
+      lastUpdated: expiredTimestamp,
+      fulfillment: { type: 'delivery' }
     };
     localStorage.setItem('cart_v1', getPersistedStateString(expiredCartStateForStorage)); // Use global mock
 

--- a/src/stores/useCartStore.test.ts
+++ b/src/stores/useCartStore.test.ts
@@ -228,4 +228,17 @@ describe('useCartStore with localStorage persistence', () => {
     expect(localStorage.getItem).toHaveBeenCalledWith(testKey);
     expect(localStorage.getItem).toHaveBeenCalledTimes(1);
   });
+
+  it('allows changing fulfillment mode with existing items', () => {
+    const { addItem, setFulfillment } = useCartStore.getState();
+    addItem(mockProduct1, 1);
+    expect(useCartStore.getState().fulfillment?.type).toBe('delivery');
+    setFulfillment({
+      type: 'pickup',
+      store: { storeId: '1', storeName: 'Test', address: 'Street' }
+    });
+    expect(useCartStore.getState().fulfillment?.type).toBe('pickup');
+    setFulfillment({ type: 'delivery' });
+    expect(useCartStore.getState().fulfillment?.type).toBe('delivery');
+  });
 });

--- a/src/stores/useCartStore.ts
+++ b/src/stores/useCartStore.ts
@@ -148,18 +148,6 @@ export const useCartStore = create<CartState>()(
       },
 
       setFulfillment: (info) => {
-        const state = get();
-        if (
-          state.items.length > 0 &&
-          state.fulfillment &&
-          (state.fulfillment.type !== info.type ||
-            (info.type === 'pickup' &&
-              state.fulfillment.type === 'pickup' &&
-              state.fulfillment.store?.storeId !== info.store?.storeId))
-        ) {
-          console.warn('Cannot change fulfillment mode/store with existing cart items');
-          return false;
-        }
         set({ fulfillment: info, lastUpdated: Date.now() });
         return true;
       }

--- a/src/stores/useCartStore.ts
+++ b/src/stores/useCartStore.ts
@@ -11,10 +11,20 @@ export interface CartItem {
   pricePerUnit: number; // Price at the time of adding to cart
 }
 
+export interface FulfillmentInfo {
+  type: 'delivery' | 'pickup';
+  store?: {
+    storeId: string;
+    storeName: string;
+    address: string;
+  };
+}
+
 // Define the state structure for the cart
 interface CartState {
   items: CartItem[];
   lastUpdated: number | null;
+  fulfillment: FulfillmentInfo | null;
   // addItem's signature matches the request, quantity is the amount to add
   addItem: (product: z.infer<typeof ProductSchema>, quantityToAdd?: number) => void;
   // updateQuantity's signature matches updateItemQuantity
@@ -24,6 +34,7 @@ interface CartState {
   getTotalItems: () => number;
   getCartSubtotal: () => number;
   getCartTotalDiscount: () => number; // Added selector for total discount
+  setFulfillment: (info: FulfillmentInfo) => boolean;
 }
 
 const SEVEN_DAYS_IN_MS = 7 * 24 * 60 * 60 * 1000;
@@ -33,8 +44,13 @@ export const useCartStore = create<CartState>()(
     (set, get) => ({
       items: [],
       lastUpdated: null,
+      fulfillment: null,
 
       addItem: (product, quantityToAdd = 1) => {
+        const stateBefore = get();
+        if (!stateBefore.fulfillment) {
+          set({ fulfillment: { type: 'delivery' }, lastUpdated: Date.now() });
+        }
         set((state) => {
           const existingItemIndex = state.items.findIndex(
             (item) => item.product.id === product.id
@@ -108,7 +124,7 @@ export const useCartStore = create<CartState>()(
       },
 
       clearCart: () => {
-        set({ items: [], lastUpdated: Date.now() }); // Ensures lastUpdated is set on clear
+        set({ items: [], lastUpdated: Date.now(), fulfillment: null }); // Ensures lastUpdated is set on clear
       },
 
       getTotalItems: () => {
@@ -129,6 +145,23 @@ export const useCartStore = create<CartState>()(
           return total + item.product.price * item.quantity;
         }, 0);
         return totalOriginalPrice - getCartSubtotal();
+      },
+
+      setFulfillment: (info) => {
+        const state = get();
+        if (
+          state.items.length > 0 &&
+          state.fulfillment &&
+          (state.fulfillment.type !== info.type ||
+            (info.type === 'pickup' &&
+              state.fulfillment.type === 'pickup' &&
+              state.fulfillment.store?.storeId !== info.store?.storeId))
+        ) {
+          console.warn('Cannot change fulfillment mode/store with existing cart items');
+          return false;
+        }
+        set({ fulfillment: info, lastUpdated: Date.now() });
+        return true;
       }
     }),
     {
@@ -163,7 +196,11 @@ export const useCartStore = create<CartState>()(
           }
         };
       },
-      partialize: (state) => ({ items: state.items, lastUpdated: state.lastUpdated }),
+      partialize: (state) => ({
+        items: state.items,
+        lastUpdated: state.lastUpdated,
+        fulfillment: state.fulfillment,
+      }),
     }
   )
 );


### PR DESCRIPTION
## Summary
- allow selecting pickup store on product page and persist choice in cart
- store order fulfillment method in cart and show selection on checkout
- display fulfillment info on order confirmation

## Testing
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_68abfdf6e648832abf2f9e02d9ccff15