### PR TITLE
feat: add product service abstraction

### DIFF
--- a/__tests__/unit/api/products-route.test.ts
+++ b/__tests__/unit/api/products-route.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from '@/app/api/products/route';
+
+vi.mock('@/lib/services', () => ({
+  createProductService: vi.fn(),
+  DEFAULT_LIMIT: 20,
+  ProductServiceError: class extends Error {
+    constructor(message: string, public status = 500) {
+      super(message);
+      this.name = 'ProductServiceError';
+    }
+  },
+}));
+
+import { createProductService, ProductServiceError } from '@/lib/services';
+
+describe('products API route', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('forwards query params to service', async () => {
+    const listProducts = vi.fn().mockResolvedValue({ items: [], total: 0, skip: 10, limit: 5 });
+    (createProductService as any).mockReturnValue({ listProducts });
+    const req = new Request('http://localhost/api/products?skip=10&limit=5');
+    const res = await GET(req as any);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ items: [], total: 0, skip: 10, limit: 5 });
+    expect(listProducts).toHaveBeenCalledWith({
+      category: undefined,
+      sort: 'relevance',
+      skip: 10,
+      limit: 5,
+      brands: undefined,
+      minPrice: undefined,
+      maxPrice: undefined,
+    });
+  });
+
+  it('maps ProductServiceError status', async () => {
+    const listProducts = vi.fn().mockRejectedValue(new ProductServiceError('bad', 502));
+    (createProductService as any).mockReturnValue({ listProducts });
+    const req = new Request('http://localhost/api/products');
+    const res = await GET(req as any);
+    expect(res.status).toBe(502);
+  });
+});

--- a/src/app/api/products/[id]/route.ts
+++ b/src/app/api/products/[id]/route.ts
@@ -1,14 +1,19 @@
-import { getProduct } from '@root/bff/products/index.js';
+import { createProductService, ProductServiceError } from '@/lib/services';
 import { NextResponse } from 'next/server';
 
 export async function GET(
   request: Request,
   { params }: { params: { id: string } }
 ) {
+  const service = createProductService();
   try {
-    const product = await getProduct(params.id);
+    const product = await service.getProduct(params.id);
     return NextResponse.json(product);
-  } catch {
-    return new Response('Error fetching product', { status: 500 });
+  } catch (error) {
+    if (error instanceof ProductServiceError) {
+      return NextResponse.json({ message: error.message }, { status: error.status });
+    }
+    console.error('Product API error:', error);
+    return NextResponse.json({ message: 'Error fetching product' }, { status: 500 });
   }
 }

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -1,7 +1,8 @@
-import { productService, DEFAULT_LIMIT } from '@/lib/services/productService';
+import { createProductService, DEFAULT_LIMIT, ProductServiceError } from '@/lib/services';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(request: NextRequest) {
+  const service = createProductService();
   const { searchParams } = new URL(request.url);
   const category = searchParams.get('category') ?? undefined;
   const sort = (searchParams.get('sort') as 'relevance' | 'price_asc' | 'price_desc' | 'newest') ?? 'relevance';
@@ -20,7 +21,7 @@ export async function GET(request: NextRequest) {
   const maxPrice = maxPriceParam ? Number(maxPriceParam) : undefined;
 
   try {
-    const results = await productService.listProducts({
+    const results = await service.listProducts({
       category,
       sort,
       skip,
@@ -35,6 +36,9 @@ export async function GET(request: NextRequest) {
       },
     });
   } catch (error) {
+    if (error instanceof ProductServiceError) {
+      return NextResponse.json({ message: error.message, items: [] }, { status: error.status });
+    }
     console.error('Products API error:', error);
     return NextResponse.json(
       { message: 'Error fetching products', items: [] },

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -1,4 +1,4 @@
-import { getProducts, DEFAULT_LIMIT } from '@/bff/services';
+import { productService, DEFAULT_LIMIT } from '@/lib/services/productService';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(request: NextRequest) {
@@ -20,7 +20,7 @@ export async function GET(request: NextRequest) {
   const maxPrice = maxPriceParam ? Number(maxPriceParam) : undefined;
 
   try {
-    const results = await getProducts({
+    const results = await productService.listProducts({
       category,
       sort,
       skip,

--- a/src/lib/services/adapters/dummyjson.productService.test.ts
+++ b/src/lib/services/adapters/dummyjson.productService.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DummyJsonProductService } from './dummyjson';
+import { ProductServiceError } from '../productService';
+import { fetchProducts, fetchProductById } from '../dummyjson';
+
+vi.mock('../dummyjson', () => ({
+  fetchProducts: vi.fn(),
+  fetchProductById: vi.fn(),
+}));
+
+describe('DummyJsonProductService', () => {
+  const service = new DummyJsonProductService();
+  const sampleProduct = {
+    id: 1,
+    title: 'Sample',
+    description: 'Desc',
+    price: 10,
+    category: { slug: 'cat', name: 'Cat' },
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('lists products', async () => {
+    (fetchProducts as any).mockResolvedValueOnce({ products: [sampleProduct], total: 1, skip: 0, limit: 1 });
+    const res = await service.listProducts();
+    expect(res.items[0].id).toBe(1);
+    expect(fetchProducts).toHaveBeenCalled();
+  });
+
+  it('throws ProductServiceError on invalid list data', async () => {
+    (fetchProducts as any).mockResolvedValueOnce({});
+    await expect(service.listProducts()).rejects.toBeInstanceOf(ProductServiceError);
+  });
+
+  it('gets product by id', async () => {
+    (fetchProductById as any).mockResolvedValueOnce(sampleProduct);
+    const res = await service.getProduct('1');
+    expect(res.id).toBe(1);
+    expect(fetchProductById).toHaveBeenCalledWith('1');
+  });
+
+  it('throws ProductServiceError when product not found', async () => {
+    (fetchProductById as any).mockResolvedValueOnce(undefined);
+    await expect(service.getProduct('2')).rejects.toBeInstanceOf(ProductServiceError);
+  });
+});

--- a/src/lib/services/adapters/dummyjson.ts
+++ b/src/lib/services/adapters/dummyjson.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+import {
+  GetProductsOptions,
+  PaginatedProductsSchema,
+  ProductSchema,
+  ServiceProductsResponseSchema,
+} from '@/bff/types';
+import { fetchProducts, fetchProductById } from '../dummyjson';
+import { ProductService, ProductServiceError } from '../productService';
+
+export class DummyJsonProductService implements ProductService {
+  readonly supports = { price: true, stock: true, facets: false } as const;
+
+  async listProducts(
+    options: GetProductsOptions = {},
+  ): Promise<z.infer<typeof ServiceProductsResponseSchema>> {
+    try {
+      const data = await fetchProducts(options);
+      const parsed = PaginatedProductsSchema.parse(data);
+      return ServiceProductsResponseSchema.parse({
+        items: parsed.products,
+        total: parsed.total,
+        skip: parsed.skip,
+        limit: parsed.limit,
+      });
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        throw new ProductServiceError('Invalid product data from source', 502);
+      }
+      throw err;
+    }
+  }
+
+  async getProduct(id: string): Promise<z.infer<typeof ProductSchema>> {
+    const data = await fetchProductById(id);
+    if (!data) {
+      throw new ProductServiceError('Product not found', 404);
+    }
+    try {
+      return ProductSchema.parse(data);
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        throw new ProductServiceError('Invalid product data from source', 502);
+      }
+      throw err;
+    }
+  }
+}

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -1,0 +1,12 @@
+export { DEFAULT_LIMIT, ProductServiceError, type ProductService, type ServiceKind } from './productService';
+export { DummyJsonProductService } from './adapters/dummyjson';
+
+export function createProductService(kind?: ServiceKind): ProductService {
+  const serviceKind = (kind ?? (process.env.PRODUCT_BACKEND as ServiceKind)) || 'dummyjson';
+  switch (serviceKind) {
+    case 'dummyjson':
+      return new DummyJsonProductService();
+    default:
+      throw new Error(`Unknown service kind: ${serviceKind}`);
+  }
+}

--- a/src/lib/services/productService.ts
+++ b/src/lib/services/productService.ts
@@ -1,40 +1,19 @@
 import { z } from 'zod';
-import {
-  GetProductsOptions,
-  PaginatedProductsSchema,
-  ProductSchema,
-  ServiceProductsResponseSchema,
-} from '@/bff/types';
-import { fetchProducts, fetchProductById } from './dummyjson';
+import { GetProductsOptions, ProductSchema, ServiceProductsResponseSchema } from '@/bff/types';
 
 export interface ProductService {
-  listProducts(
-    options?: GetProductsOptions,
-  ): Promise<z.infer<typeof ServiceProductsResponseSchema>>;
-  getProduct(id: number): Promise<z.infer<typeof ProductSchema>>;
+  listProducts(options?: GetProductsOptions): Promise<z.infer<typeof ServiceProductsResponseSchema>>;
+  getProduct(id: string): Promise<z.infer<typeof ProductSchema>>;
+  readonly supports: { price: boolean; stock: boolean; facets: boolean };
 }
 
 export const DEFAULT_LIMIT = 20;
 
-export class DummyJsonProductService implements ProductService {
-  async listProducts(
-    options: GetProductsOptions = {},
-  ): Promise<z.infer<typeof ServiceProductsResponseSchema>> {
-    const data = await fetchProducts(options);
-    const parsed = PaginatedProductsSchema.parse(data);
-    return ServiceProductsResponseSchema.parse({
-      items: parsed.products,
-      total: parsed.total,
-      skip: parsed.skip,
-      limit: parsed.limit,
-    });
-  }
+export type ServiceKind = 'dummyjson';
 
-  async getProduct(id: number): Promise<z.infer<typeof ProductSchema>> {
-    const data = await fetchProductById(id);
-    return ProductSchema.parse(data);
+export class ProductServiceError extends Error {
+  constructor(message: string, public readonly status = 500) {
+    super(message);
+    this.name = 'ProductServiceError';
   }
 }
-
-export const productService: ProductService = new DummyJsonProductService();
-

--- a/src/lib/services/productService.ts
+++ b/src/lib/services/productService.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+import {
+  GetProductsOptions,
+  PaginatedProductsSchema,
+  ProductSchema,
+  ServiceProductsResponseSchema,
+} from '@/bff/types';
+import { fetchProducts, fetchProductById } from './dummyjson';
+
+export interface ProductService {
+  listProducts(
+    options?: GetProductsOptions,
+  ): Promise<z.infer<typeof ServiceProductsResponseSchema>>;
+  getProduct(id: number): Promise<z.infer<typeof ProductSchema>>;
+}
+
+export const DEFAULT_LIMIT = 20;
+
+export class DummyJsonProductService implements ProductService {
+  async listProducts(
+    options: GetProductsOptions = {},
+  ): Promise<z.infer<typeof ServiceProductsResponseSchema>> {
+    const data = await fetchProducts(options);
+    const parsed = PaginatedProductsSchema.parse(data);
+    return ServiceProductsResponseSchema.parse({
+      items: parsed.products,
+      total: parsed.total,
+      skip: parsed.skip,
+      limit: parsed.limit,
+    });
+  }
+
+  async getProduct(id: number): Promise<z.infer<typeof ProductSchema>> {
+    const data = await fetchProductById(id);
+    return ProductSchema.parse(data);
+  }
+}
+
+export const productService: ProductService = new DummyJsonProductService();
+


### PR DESCRIPTION
## Summary
- add ProductService interface and dummy implementation
- update products API route to use ProductService

## Testing
- `pnpm test run`

------
https://chatgpt.com/codex/tasks/task_e_68ac0738e698832a8f7ade0f896758b1