### PR TITLE
feat: introduce backend adapters and wire into BFF

### DIFF
--- a/src/adapters/auth/dummyjson.ts
+++ b/src/adapters/auth/dummyjson.ts
@@ -1,0 +1,11 @@
+import { AuthAdapter } from './index';
+import { login, DummyJsonLoginApiSchema } from '@/lib/services/dummyjson';
+import { fetchData } from '@/utils/fetchData';
+
+const dummyJsonAuthAdapter: AuthAdapter = {
+  getUsers: () => fetchData('https://dummyjson.com/users'),
+  login,
+};
+
+export { DummyJsonLoginApiSchema };
+export default dummyJsonAuthAdapter;

--- a/src/adapters/auth/index.ts
+++ b/src/adapters/auth/index.ts
@@ -1,0 +1,10 @@
+export interface AuthAdapter {
+  getUsers(): Promise<unknown>;
+  login(credentials: { username: string; password: string }): Promise<unknown>;
+}
+
+import dummyJsonAuthAdapter from './dummyjson';
+export { DummyJsonLoginApiSchema } from './dummyjson';
+
+export const authAdapter: AuthAdapter = dummyJsonAuthAdapter;
+export default authAdapter;

--- a/src/adapters/cms/dummyjson.ts
+++ b/src/adapters/cms/dummyjson.ts
@@ -1,0 +1,8 @@
+import { CMSAdapter } from './index';
+import { fetchData } from '@/utils/fetchData';
+
+const dummyJsonCMSAdapter: CMSAdapter = {
+  getContent: () => fetchData('https://dummyjson.com/posts'),
+};
+
+export default dummyJsonCMSAdapter;

--- a/src/adapters/cms/index.ts
+++ b/src/adapters/cms/index.ts
@@ -1,0 +1,8 @@
+export interface CMSAdapter {
+  getContent(): Promise<unknown>;
+}
+
+import dummyJsonCMSAdapter from './dummyjson';
+
+export const cmsAdapter: CMSAdapter = dummyJsonCMSAdapter;
+export default cmsAdapter;

--- a/src/adapters/commerce/dummyjson.ts
+++ b/src/adapters/commerce/dummyjson.ts
@@ -1,0 +1,18 @@
+import { CommerceAdapter } from './types';
+import {
+  fetchAllProductsSimple,
+  fetchProducts,
+  fetchProductById,
+  fetchCategories,
+} from '@/lib/services/dummyjson';
+import { fetchData } from '@/utils/fetchData';
+
+const dummyJsonCommerceAdapter: CommerceAdapter = {
+  fetchAllProductsSimple,
+  fetchProducts,
+  fetchProductById,
+  fetchCategories,
+  fetchOrders: () => fetchData('https://dummyjson.com/carts'),
+};
+
+export default dummyJsonCommerceAdapter;

--- a/src/adapters/commerce/index.ts
+++ b/src/adapters/commerce/index.ts
@@ -1,0 +1,5 @@
+export type { CommerceAdapter } from './types';
+import dummyJsonCommerceAdapter from './dummyjson';
+
+export const commerceAdapter = dummyJsonCommerceAdapter;
+export default commerceAdapter;

--- a/src/adapters/commerce/types.ts
+++ b/src/adapters/commerce/types.ts
@@ -1,0 +1,9 @@
+import { GetProductsOptions } from '@/bff/types';
+
+export interface CommerceAdapter {
+  fetchAllProductsSimple(): Promise<unknown>;
+  fetchProducts(options: GetProductsOptions): Promise<unknown>;
+  fetchProductById(id: number | string): Promise<unknown>;
+  fetchCategories(fetchOptions?: RequestInit): Promise<unknown>;
+  fetchOrders(): Promise<unknown>;
+}

--- a/src/adapters/search/dummyjson.ts
+++ b/src/adapters/search/dummyjson.ts
@@ -1,0 +1,9 @@
+import { SearchAdapter } from './index';
+import { fetchData } from '@/utils/fetchData';
+
+const dummyJsonSearchAdapter: SearchAdapter = {
+  search: (query: string, _sort?: string, _skip?: number, _limit?: number) =>
+    fetchData(`https://dummyjson.com/products/search?q=${encodeURIComponent(query)}`),
+};
+
+export default dummyJsonSearchAdapter;

--- a/src/adapters/search/dummyjson.ts
+++ b/src/adapters/search/dummyjson.ts
@@ -2,8 +2,14 @@ import { SearchAdapter } from './index';
 import { fetchData } from '@/utils/fetchData';
 
 const dummyJsonSearchAdapter: SearchAdapter = {
-  search: (query: string, _sort?: string, _skip?: number, _limit?: number) =>
-    fetchData(`https://dummyjson.com/products/search?q=${encodeURIComponent(query)}`),
+  search: (query: string, sort?: string, skip?: number, limit?: number) => {
+    const url = new URL('https://dummyjson.com/products/search');
+    url.searchParams.set('q', query);
+    if (sort) url.searchParams.set('sort', sort);
+    if (typeof skip === 'number') url.searchParams.set('skip', String(skip));
+    if (typeof limit === 'number') url.searchParams.set('limit', String(limit));
+    return fetchData(url.toString());
+  },
 };
 
 export default dummyJsonSearchAdapter;

--- a/src/adapters/search/index.ts
+++ b/src/adapters/search/index.ts
@@ -1,0 +1,8 @@
+export interface SearchAdapter {
+  search(query: string, sort?: string, skip?: number, limit?: number): Promise<unknown>;
+}
+
+import dummyJsonSearchAdapter from './dummyjson';
+
+export const searchAdapter: SearchAdapter = dummyJsonSearchAdapter;
+export default searchAdapter;

--- a/src/bff/cms-content/index.js
+++ b/src/bff/cms-content/index.js
@@ -1,4 +1,4 @@
-import { fetchData } from '@/utils/fetchData';
+import { cmsAdapter } from '@/adapters/cms';
 import appInsights from 'applicationinsights';
 
 /**
@@ -15,7 +15,7 @@ export async function getCMSContent() {
     });
 
     // Assuming a dummy endpoint for CMS content, using posts as an example
-    const data = await fetchData('https://dummyjson.com/posts');
+    const data = await cmsAdapter.getContent();
 
     client.trackEvent({
       name: 'CmsContentFetchSuccess',

--- a/src/bff/orders/index.js
+++ b/src/bff/orders/index.js
@@ -1,4 +1,4 @@
-import { fetchData } from '@/utils/fetchData';
+import { commerceAdapter } from '@/adapters/commerce';
 import appInsights from 'applicationinsights';
 
 /**
@@ -15,7 +15,7 @@ export async function getOrders() {
     });
 
     // Assuming a dummy endpoint for orders, replace with actual if available
-    const data = await fetchData('https://dummyjson.com/carts'); // Using carts as a proxy for orders
+    const data = await commerceAdapter.fetchOrders(); // Using carts as a proxy for orders
 
     client.trackEvent({
       name: 'OrdersFetchSuccess',

--- a/src/bff/products/index.js
+++ b/src/bff/products/index.js
@@ -1,4 +1,4 @@
-import { fetchData } from '@/utils/fetchData';
+import { commerceAdapter } from '@/adapters/commerce';
 import appInsights from 'applicationinsights';
 
 /**
@@ -14,7 +14,7 @@ export async function getProducts() {
       properties: { origin: 'bff/products', method: 'getProducts' },
     });
 
-    const data = await fetchData('https://dummyjson.com/products');
+    const data = await commerceAdapter.fetchProducts({});
 
     client.trackEvent({
       name: 'ProductsFetchSuccess',
@@ -49,7 +49,7 @@ export async function getProducts() {
  */
 export async function getProduct(id) {
   try {
-    const data = await fetchData(`https://dummyjson.com/products/${id}`);
+    const data = await commerceAdapter.fetchProductById(id);
     return data;
   } catch (error) {
     console.error(error);

--- a/src/bff/products/search.js
+++ b/src/bff/products/search.js
@@ -1,4 +1,4 @@
-import { fetchData } from '@/utils/fetchData';
+import { searchAdapter } from '@/adapters/search';
 import appInsights from 'applicationinsights';
 
 /**
@@ -15,9 +15,7 @@ export async function searchProducts(query) {
       properties: { origin: 'bff/products', method: 'searchProducts' },
     });
 
-    const data = await fetchData(
-      `https://dummyjson.com/products/search?q=${encodeURIComponent(query)}`
-    );
+    const data = await searchAdapter.search(query);
 
     client.trackEvent({
       name: 'ProductSearchSuccess',

--- a/src/bff/users/index.js
+++ b/src/bff/users/index.js
@@ -1,4 +1,4 @@
-import { fetchData } from '@/utils/fetchData';
+import { authAdapter } from '@/adapters/auth';
 import appInsights from 'applicationinsights';
 
 /**
@@ -14,7 +14,7 @@ export async function getUsers() {
       properties: { origin: 'bff/users', method: 'getUsers' },
     });
 
-    const data = await fetchData('https://dummyjson.com/users');
+    const data = await authAdapter.getUsers();
 
     client.trackEvent({
       name: 'UsersFetchSuccess',


### PR DESCRIPTION
## Summary
- add adapter interfaces for commerce, CMS, search, and auth with dummyjson implementations
- update BFF modules and services to consume the new adapters

## Testing
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_68ac6ed97ebc832abe2832dcc2bed428