### PR TITLE
feat: add store finder pages and links

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { Suspense } from 'react';
 import { Toaster } from 'react-hot-toast'; // Import Toaster
 import RootClientProviders from '@/components/RootClientProviders';
 import { CompanyProvider } from '@/contexts/CompanyProvider';
+import Footer from '@/components/Footer';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -56,6 +57,7 @@ export default async function RootLayout({
             <main className="mx-auto max-w-7xl px-2 sm:px-6 lg:px-8 py-6">
               {children}
             </main>
+            <Footer />
           </CompanyProvider>
         </RootClientProviders>
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -131,9 +131,6 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <footer className="py-8 text-center text-gray-500 border-t">
-        <p>&copy; {new Date().getFullYear()} BetaStore. All rights reserved.</p>
-      </footer>
     </div>
   );
 }

--- a/src/app/stores/[id]/page.tsx
+++ b/src/app/stores/[id]/page.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import stores from '@/fixtures/mockStoreStock.json';
+
+interface Params {
+  params: { id: string };
+}
+
+export const metadata = {
+  title: 'Store Details',
+};
+
+export default function StoreDetailsPage({ params }: Params) {
+  const store = stores.find((s) => s.storeId === params.id);
+  if (!store) {
+    notFound();
+  }
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-2">{store.storeName}</h1>
+      <p className="mb-4 text-gray-600">{store.address}</p>
+      <Link href="/stores" className="text-primary hover:text-accent">
+        Back to store list
+      </Link>
+    </div>
+  );
+}

--- a/src/app/stores/page.tsx
+++ b/src/app/stores/page.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+import stores from '@/fixtures/mockStoreStock.json';
+
+export const metadata = {
+  title: 'Find a Store',
+};
+
+export default function StoresPage() {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Find a store</h1>
+      <ul className="space-y-4">
+        {stores.map((store) => (
+          <li key={store.storeId} className="border-b pb-4">
+            <Link href={`/stores/${store.storeId}`} className="block hover:text-accent">
+              <h2 className="text-xl font-semibold">{store.storeName}</h2>
+              <p className="text-sm text-gray-600">{store.address}</p>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+
+export default function Footer() {
+  return (
+    <footer className="py-8 text-center text-gray-500 border-t">
+      <div className="mb-4">
+        <Link href="/stores" className="text-primary hover:text-accent">
+          Find my nearest store
+        </Link>
+      </div>
+      <p>&copy; {new Date().getFullYear()} BetaStore. All rights reserved.</p>
+    </footer>
+  );
+}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -47,6 +47,7 @@ export default function NavBar({ initialCategories, categoryError }: NavBarProps
 
   const navigation = [
     { name: 'Home', href: '/', current: pathname === '/' },
+    { name: 'Find Store', href: '/stores', current: pathname === '/stores' },
     ...allCategoryItems,
   ];
 


### PR DESCRIPTION
## Summary
- implement store listing and detail pages from existing store data
- add global footer with "Find my nearest store" link
- expose store finder link in main navigation

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_68ac73c3c8d4832ab9136113c437c290