### PR TITLE
feat: migrate BFF endpoints to TypeScript

### DIFF
--- a/src/bff/README.md
+++ b/src/bff/README.md
@@ -5,14 +5,14 @@ This directory contains mock backend-for-frontend functions for fetching data fr
 ## Directory Structure
 
 - **cms-content/**
-  - `index.js`: Fetches CMS content (simulated using dummyjson.com/posts).
+  - `index.ts`: Fetches CMS content (simulated using dummyjson.com/posts).
 - **orders/**
-  - `index.js`: Fetches order data (simulated using dummyjson.com/carts).
+  - `index.ts`: Fetches order data (simulated using dummyjson.com/carts).
 - **products/**
-  - `index.js`: Fetches product data (simulated using dummyjson.com/products).
-  - `search.js`: Searches for products by keyword using dummyjson.com.
+  - `index.ts`: Fetches product data (simulated using dummyjson.com/products).
+  - `search.ts`: Searches for products by keyword using dummyjson.com.
 - **users/**
-  - `index.js`: Fetches user data (simulated using dummyjson.com/users).
+  - `index.ts`: Fetches user data (simulated using dummyjson.com/users).
 - **fixtures/**
   - `mock-category-data.json`: Example category and product data used by the BFF (located under `src/fixtures`).
 - **helpers/** and **services/**: Shared utilities and server-side services.
@@ -20,7 +20,7 @@ This directory contains mock backend-for-frontend functions for fetching data fr
 
 ## Services
 
-Each service in its respective subdirectory (e.g., `products`, `users`) exports functions to fetch data. For example, `src/bff/products/index.js` exports a `getProducts` function.
+Each service in its respective subdirectory (e.g., `products`, `users`) exports functions to fetch data. For example, `src/bff/products/index.ts` exports a `getProducts` function.
 
 ## Utility Functions
 

--- a/src/bff/products/index.ts
+++ b/src/bff/products/index.ts
@@ -1,11 +1,16 @@
 import { commerceAdapter } from '@/adapters/commerce';
 import appInsights from 'applicationinsights';
+import { z } from 'zod';
+import { PaginatedProductsSchema, ProductSchema } from '../types';
+
+export type PaginatedProducts = z.infer<typeof PaginatedProductsSchema>;
+export type Product = z.infer<typeof ProductSchema>;
 
 /**
  * Fetches product data from dummyjson.com.
- * @returns {Promise<Object>} A promise that resolves to the product data.
+ * @returns A promise that resolves to the product data.
  */
-export async function getProducts() {
+export async function getProducts(): Promise<PaginatedProducts> {
   const client = appInsights.defaultClient;
   try {
     client.trackTrace({
@@ -15,27 +20,28 @@ export async function getProducts() {
     });
 
     const data = await commerceAdapter.fetchProducts({});
+    const parsed = PaginatedProductsSchema.parse(data);
 
     client.trackEvent({
       name: 'ProductsFetchSuccess',
       properties: {
         source: 'dummyjson',
-        userType: 'anonymous', // Assuming anonymous for now, can be enhanced with actual user context
-        resultCount: data?.products?.length ?? 0,
+        userType: 'anonymous', // Assuming anonymous for now
+        resultCount: parsed.products.length,
       },
     });
 
-    if (data?.products?.length) {
+    if (parsed.products.length) {
       client.trackMetric({
         name: 'ProductsReturned',
-        value: data.products.length,
+        value: parsed.products.length,
       });
     }
 
-    return data;
+    return parsed;
   } catch (error) {
     client.trackException({
-      exception: error,
+      exception: error as Error,
       properties: { origin: 'bff/products', method: 'getProducts' },
     });
     throw error; // Re-throw the error so the caller can handle it
@@ -44,13 +50,13 @@ export async function getProducts() {
 
 /**
  * Fetches a single product by id from dummyjson.com.
- * @param {string|number} id - The product id.
- * @returns {Promise<Object>} The product data.
+ * @param id - The product id.
+ * @returns The product data.
  */
-export async function getProduct(id) {
+export async function getProduct(id: string | number): Promise<Product> {
   try {
     const data = await commerceAdapter.fetchProductById(id);
-    return data;
+    return ProductSchema.parse(data);
   } catch (error) {
     console.error(error);
     throw error;

--- a/src/bff/types.ts
+++ b/src/bff/types.ts
@@ -78,3 +78,24 @@ export const ServiceProductsResponseSchema = z.object({
   skip: z.number(),
   limit: z.number(),
 });
+
+export const UsersResponseSchema = z.object({
+  users: z.array(UserSchema),
+  total: z.number(),
+  skip: z.number(),
+  limit: z.number(),
+});
+
+export const OrdersResponseSchema = z.object({
+  carts: z.array(z.unknown()),
+  total: z.number().optional(),
+  skip: z.number().optional(),
+  limit: z.number().optional(),
+});
+
+export const CMSContentResponseSchema = z.object({
+  posts: z.array(z.unknown()),
+  total: z.number().optional(),
+  skip: z.number().optional(),
+  limit: z.number().optional(),
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,6 @@
       }
     ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"], // Adjusted include
+  "include": ["next-env.d.ts", "src/bff/**/*.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"], // Adjusted include
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- convert BFF endpoints for users, orders, products, search, and CMS content to TypeScript
- add Zod schemas for user, order, and CMS responses
- include BFF directory in tsconfig for compilation

## Testing
- `pnpm lint`
- `pnpm vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68ac884623e4832a911b0e5127d4c8b1